### PR TITLE
Accept options with read only properties

### DIFF
--- a/lib/BaseRollingFileStream.js
+++ b/lib/BaseRollingFileStream.js
@@ -12,11 +12,7 @@ module.exports = BaseRollingFileStream;
 function BaseRollingFileStream(filename, options) {
   debug("In BaseRollingFileStream");
   this.filename = filename;
-  this.options = options || {};
-  this.options.encoding = this.options.encoding || 'utf8';
-  this.options.mode = this.options.mode || parseInt('0644', 8);
-  this.options.flags = this.options.flags || 'a';
-
+  this.options = Object.assign({ encoding: 'utf-8', mode: parseInt('0644', 8), flags: 'a' }, options);
   this.currentSize = 0;
 
   function currentFileSize(file) {


### PR DESCRIPTION
If the options properties are defined using the Object.defineProperty() method as read-only
```javascript
'use strict';

let rollers = require('streamroller');

let options = {};
Object.defineProperty(options, 'flags', {
  value: 'w',
  writable: false
});

let stream = new rollers.RollingFileStream('myfile', 1024, 3, options);
```
it will be thrown TypeError "Cannot assign to read only property 'flags' of object '#<Object>'".

_I got this error when using node log4js, when set property "flags" in appenders._

**This commit fix it.**