### PR TITLE
fix: was crashing when pattern is all digits

### DIFF
--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -187,19 +187,20 @@ class RollingFileWriteStream extends Writable {
       if (indexStr !== undefined && indexStr.match(/^\d+$/)) {
         const dateStr = metaStr.slice(0, -1 * (indexStr.length + 1));
         debug(`dateStr is ${dateStr}`);
-        return {
-            index: parseInt(indexStr, 10),
-            date: format.parse(this.options.pattern, dateStr),
-            isCompressed
-          };
-      } else {
-        debug(`metaStr is ${metaStr}`);
+        if (dateStr) {
           return {
-            index: 0,
-            date: format.parse(this.options.pattern, metaStr),
-            isCompressed
-          };
+              index: parseInt(indexStr, 10),
+              date: format.parse(this.options.pattern, dateStr),
+              isCompressed
+            };
+        }
       }
+      debug(`metaStr is ${metaStr}`);
+      return {
+        index: 0,
+        date: format.parse(this.options.pattern, metaStr),
+        isCompressed
+      };
     } else {
       if (metaStr.match(/^\d+$/)) {
         return {


### PR DESCRIPTION
This was an error I found when testing some stuff in log4js. If the date pattern is something like '.yyyyMMdd', or even just '.ss' then the date rolling was identifying the date part of the filename as the index and crashing because it could not find the date part.