### PR TITLE
fix: pick up existing backups

### DIFF
--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -1,43 +1,61 @@
-const debug = require('debug')('streamroller:RollingFileWriteStream');
-const _ = require('lodash');
-const async = require('async');
-const fs = require('fs-extra');
-const zlib = require('zlib');
-const path = require('path');
-const newNow = require('./now');
-const format = require('date-format');
-const { Writable } = require('stream');
+const debug = require("debug")("streamroller:RollingFileWriteStream");
+const _ = require("lodash");
+const async = require("async");
+const fs = require("fs-extra");
+const zlib = require("zlib");
+const path = require("path");
+const newNow = require("./now");
+const format = require("date-format");
+const { Writable } = require("stream");
 
-const FILENAME_SEP = '.';
-const ZIP_EXT = '.gz';
+const FILENAME_SEP = ".";
+const ZIP_EXT = ".gz";
 
-const moveAndMaybeCompressFile = (sourceFilePath, targetFilePath, needCompress, done) => {
+const moveAndMaybeCompressFile = (
+  sourceFilePath,
+  targetFilePath,
+  needCompress,
+  done
+) => {
   if (sourceFilePath === targetFilePath) {
-    debug(`moveAndMaybeCompressFile: source and target are the same, not doing anything`);
+    debug(
+      `moveAndMaybeCompressFile: source and target are the same, not doing anything`
+    );
     return done();
   }
-  fs.access(sourceFilePath, fs.constants.W_OK | fs.constants.R_OK,  (e) => {
+  fs.access(sourceFilePath, fs.constants.W_OK | fs.constants.R_OK, e => {
     if (e) {
-      debug(`moveAndMaybeCompressFile: source file path does not exist. not moving. sourceFilePath=${sourceFilePath}`);
+      debug(
+        `moveAndMaybeCompressFile: source file path does not exist. not moving. sourceFilePath=${sourceFilePath}`
+      );
       return done();
     }
 
-    debug(`moveAndMaybeCompressFile: moving file from ${sourceFilePath} to ${targetFilePath} ${needCompress ? 'with' : 'without'} compress`);
+    debug(
+      `moveAndMaybeCompressFile: moving file from ${sourceFilePath} to ${targetFilePath} ${
+        needCompress ? "with" : "without"
+      } compress`
+    );
     if (needCompress) {
       fs.createReadStream(sourceFilePath)
         .pipe(zlib.createGzip())
         .pipe(fs.createWriteStream(targetFilePath))
-        .on('finish', () => {
-          debug(`moveAndMaybeCompressFile: finished compressing ${targetFilePath}, deleting ${sourceFilePath}`);
+        .on("finish", () => {
+          debug(
+            `moveAndMaybeCompressFile: finished compressing ${targetFilePath}, deleting ${sourceFilePath}`
+          );
           fs.unlink(sourceFilePath, done);
         });
     } else {
-      debug(`moveAndMaybeCompressFile: deleting file=${targetFilePath}, renaming ${sourceFilePath} to ${targetFilePath}`);
-      fs.unlink(targetFilePath, () => { fs.rename(sourceFilePath, targetFilePath, done); });
+      debug(
+        `moveAndMaybeCompressFile: deleting file=${targetFilePath}, renaming ${sourceFilePath} to ${targetFilePath}`
+      );
+      fs.unlink(targetFilePath, () => {
+        fs.rename(sourceFilePath, targetFilePath, done);
+      });
     }
   });
 };
-
 
 /**
  * RollingFileWriteStream is mainly used when writing to a file rolling by date or size.
@@ -64,31 +82,38 @@ class RollingFileWriteStream extends Writable {
     super(options);
     this.options = this._parseOption(options);
     this.fileObject = path.parse(filePath);
-    if (this.fileObject.dir === '') {
+    if (this.fileObject.dir === "") {
       this.fileObject = path.parse(path.join(process.cwd(), filePath));
     }
-    this.justTheFile = this._formatFileName({isHotFile: true});
+    this.justTheFile = this._formatFileName({ isHotFile: true });
     this.filename = path.join(this.fileObject.dir, this.justTheFile);
     this.state = {
-      currentDate: newNow(),
-      currentIndex: 0,
       currentSize: 0
     };
 
-    if (this.options.flags === 'a') {
+    if (this.options.pattern) {
+      this.state.currentDate = format(this.options.pattern, newNow());
+    }
+
+    if (this.options.flags === "a") {
       this._setExistingSizeAndDate();
     }
 
-    debug(`create new file with no hot file. name=${this.justTheFile}, state=${JSON.stringify(this.state)}`);
+    debug(
+      `create new file with no hot file. name=${
+        this.justTheFile
+      }, state=${JSON.stringify(this.state)}`
+    );
     this._renewWriteStream();
-
   }
 
   _setExistingSizeAndDate() {
     try {
       const stats = fs.statSync(this.filename);
       this.state.currentSize = stats.size;
-      this.state.currentDate = stats.birthtime;
+      if (this.options.pattern) {
+        this.state.currentDate = format(this.options.pattern, stats.birthtime);
+      }
     } catch (e) {
       //file does not exist, that's fine - move along
       return;
@@ -99,9 +124,9 @@ class RollingFileWriteStream extends Writable {
     const defaultOptions = {
       maxSize: Number.MAX_SAFE_INTEGER,
       numToKeep: Number.MAX_SAFE_INTEGER,
-      encoding: 'utf8',
-      mode: parseInt('0644', 8),
-      flags: 'a',
+      encoding: "utf8",
+      mode: parseInt("0644", 8),
+      flags: "a",
       compress: false,
       keepFileExt: false,
       alwaysIncludePattern: false
@@ -110,7 +135,7 @@ class RollingFileWriteStream extends Writable {
     if (options.maxSize <= 0) {
       throw new Error(`options.maxSize (${options.maxSize}) should be > 0`);
     }
-    if (options.numToKeep < 1) {
+    if (options.numToKeep <= 0) {
       throw new Error(`options.numToKeep (${options.numToKeep}) should be > 0`);
     }
     debug(`creating stream with option=${JSON.stringify(options)}`);
@@ -118,27 +143,37 @@ class RollingFileWriteStream extends Writable {
   }
 
   _shouldRoll(callback) {
-      debug(`in _shouldRoll, pattern = ${this.options.pattern}, currentDate = ${this.state.currentDate}, now = ${newNow()}`);
-      if (this.options.pattern && (format(this.options.pattern, this.state.currentDate) !== format(this.options.pattern, newNow()))) {
-        this._roll({isNextPeriod: true}, callback);
-        return;
-      }
-      debug(`in _shouldRoll, currentSize = ${this.state.currentSize}, maxSize = ${this.options.maxSize}`);
-      if (this.state.currentSize >= this.options.maxSize) {
-        this._roll({isNextPeriod: false}, callback);
-        return;
-      }
-      callback();
+    if (
+      this.state.currentDate &&
+      this.state.currentDate !== format(this.options.pattern, newNow())
+    ) {
+      debug(
+        `_shouldRoll: rolling by date because ${
+          this.state.currentDate
+        } !== ${format(this.options.pattern, newNow())}`
+      );
+      this._roll({ isNextPeriod: true }, callback);
+      return;
+    }
+    if (this.state.currentSize >= this.options.maxSize) {
+      debug(
+        `_shouldRoll: rolling by size because ${this.state.currentSize} >= ${this.options.maxSize}`
+      );
+      this._roll({ isNextPeriod: false }, callback);
+      return;
+    }
+    callback();
   }
 
   _write(chunk, encoding, callback) {
     this._shouldRoll(() => {
-      debug(`writing chunk. ` +
-        `file=${this.currentFileStream.path} ` +
-        `state=${JSON.stringify(this.state)} ` +
-        `chunk=${chunk}`
+      debug(
+        `writing chunk. ` +
+          `file=${this.currentFileStream.path} ` +
+          `state=${JSON.stringify(this.state)} ` +
+          `chunk=${chunk}`
       );
-      this.currentFileStream.write(chunk, encoding, (e) => {
+      this.currentFileStream.write(chunk, encoding, e => {
         this.state.currentSize += chunk.length;
         callback(e);
       });
@@ -152,17 +187,23 @@ class RollingFileWriteStream extends Writable {
       const existingFileDetails = _.compact(
         _.map(files, n => {
           const parseResult = this._parseFileName(n);
-          debug(`_getExistingFiles: parsed ${n} as ${parseResult}`);
+          debug(`_getExistingFiles: parsed ${n} as `, parseResult);
           if (!parseResult) {
             return;
           }
-          return _.assign({fileName: n}, parseResult);
+          return _.assign({ fileName: n }, parseResult);
         })
       );
-      cb(null, _.sortBy(
-        existingFileDetails,
-        n => (n.date ? n.date.valueOf() : newNow().valueOf()) - n.index
-      ));
+      cb(
+        null,
+        _.sortBy(
+          existingFileDetails,
+          n =>
+            (n.date
+              ? format.parse(this.options.pattern, n.date).valueOf()
+              : newNow().valueOf()) - n.index
+        )
+      );
     });
   }
 
@@ -181,13 +222,15 @@ class RollingFileWriteStream extends Writable {
         return;
       }
       metaStr = fileName.slice(prefix.length, -1 * suffix.length);
-      debug(`metaStr=${metaStr}, fileName=${fileName}, prefix=${prefix}, suffix=${suffix}`);
+      debug(
+        `metaStr=${metaStr}, fileName=${fileName}, prefix=${prefix}, suffix=${suffix}`
+      );
     } else {
       const prefix = this.fileObject.base;
       if (!fileName.startsWith(prefix)) {
         return;
       }
-      metaStr = fileName.slice(prefix.length);
+      metaStr = fileName.slice(prefix.length + 1);
       debug(`metaStr=${metaStr}, fileName=${fileName}, prefix=${prefix}`);
     }
     if (!metaStr) {
@@ -199,22 +242,22 @@ class RollingFileWriteStream extends Writable {
     if (this.options.pattern) {
       const items = _.split(metaStr, FILENAME_SEP);
       const indexStr = items[items.length - 1];
-      debug('items: ', items, ', indexStr: ', indexStr);
+      debug("items: ", items, ", indexStr: ", indexStr);
       if (indexStr !== undefined && indexStr.match(/^\d+$/)) {
         const dateStr = metaStr.slice(0, -1 * (indexStr.length + 1));
         debug(`dateStr is ${dateStr}`);
         if (dateStr) {
           return {
-              index: parseInt(indexStr, 10),
-              date: format.parse(this.options.pattern, dateStr),
-              isCompressed
-            };
+            index: parseInt(indexStr, 10),
+            date: dateStr,
+            isCompressed
+          };
         }
       }
       debug(`metaStr is ${metaStr}`);
       return {
         index: 0,
-        date: format.parse(this.options.pattern, metaStr),
+        date: metaStr,
         isCompressed
       };
     } else {
@@ -228,16 +271,26 @@ class RollingFileWriteStream extends Writable {
     return;
   }
 
-  _formatFileName({date, index, isHotFile}) {
-    debug(`_formatFileName: date=${date}, index=${index}, isHotFile=${isHotFile}`);
-    const dateOpt = date || _.get(this, 'state.currentDate') || newNow();
-    const dateStr = format(this.options.pattern, dateOpt);
-    const indexOpt = index || _.get(this, 'state.currentIndex');
+  _formatFileName({ date, index, isHotFile }) {
+    debug(
+      `_formatFileName: date=${date}, index=${index}, isHotFile=${isHotFile}`
+    );
+    const dateStr =
+      date ||
+      _.get(this, "state.currentDate") ||
+      format(this.options.pattern, newNow());
+    const indexOpt = index || _.get(this, "state.currentIndex");
     const oriFileName = this.fileObject.base;
     if (isHotFile) {
-      debug(`_formatFileName: includePattern? ${this.options.alwaysIncludePattern}, pattern: ${this.options.pattern}`);
+      debug(
+        `_formatFileName: includePattern? ${this.options.alwaysIncludePattern}, pattern: ${this.options.pattern}`
+      );
       if (this.options.alwaysIncludePattern && this.options.pattern) {
-        debug(`_formatFileName: is hot file, and include pattern, so: ${oriFileName + FILENAME_SEP + dateStr}`);
+        debug(
+          `_formatFileName: is hot file, and include pattern, so: ${oriFileName +
+            FILENAME_SEP +
+            dateStr}`
+        );
         return this.options.keepFileExt
           ? this.fileObject.name + FILENAME_SEP + dateStr + this.fileObject.ext
           : oriFileName + FILENAME_SEP + dateStr;
@@ -254,10 +307,14 @@ class RollingFileWriteStream extends Writable {
     }
     let fileName;
     if (this.options.keepFileExt) {
-      const baseFileName = this.fileObject.name + FILENAME_SEP + fileNameExtraItems.join(FILENAME_SEP);
+      const baseFileName =
+        this.fileObject.name +
+        FILENAME_SEP +
+        fileNameExtraItems.join(FILENAME_SEP);
       fileName = baseFileName + this.fileObject.ext;
     } else {
-      fileName = oriFileName + FILENAME_SEP + fileNameExtraItems.join(FILENAME_SEP);
+      fileName =
+        oriFileName + FILENAME_SEP + fileNameExtraItems.join(FILENAME_SEP);
     }
     if (this.options.compress) {
       fileName += ZIP_EXT;
@@ -268,78 +325,113 @@ class RollingFileWriteStream extends Writable {
 
   _moveOldFiles(isNextPeriod, cb) {
     const currentFilePath = this.currentFileStream.path;
-    debug(`currentIndex = ${this.state.currentIndex}, numToKeep = ${this.options.numToKeep}`);
-    let totalFilesToMove = _.min([this.state.currentIndex, this.options.numToKeep - 1]);
-    const filesToMove = [];
-    for (let i = totalFilesToMove; i >= 0; i--) {
-      debug(`i = ${i}`);
-      const sourceFilePath = i === 0
-        ? currentFilePath
-        : path.format({
+    debug(`numToKeep = ${this.options.numToKeep}`);
+    const finishedRolling = () => {
+      if (isNextPeriod) {
+        this.state.currentSize = 0;
+        this.state.currentDate = format(this.options.pattern, newNow());
+        debug(`rolling for next period. state=${JSON.stringify(this.state)}`);
+      } else {
+        this.state.currentSize = 0;
+        debug(
+          `rolling during the same period. state=${JSON.stringify(this.state)}`
+        );
+      }
+      this._renewWriteStream();
+      // wait for the file to be open before cleaning up old ones,
+      // otherwise the daysToKeep calculations can be off
+      this.currentFileStream.write("", "utf8", () => this._clean(cb));
+    };
+
+    this._getExistingFiles((e, files) => {
+      const filesToMove = [];
+      const todaysFiles = this.state.currentDate
+        ? files.filter(f => f.date === this.state.currentDate)
+        : files;
+      for (let i = todaysFiles.length; i >= 0; i--) {
+        debug(`i = ${i}`);
+        const sourceFilePath =
+          i === 0
+            ? currentFilePath
+            : path.format({
+                dir: this.fileObject.dir,
+                base: this._formatFileName({
+                  date: this.state.currentDate,
+                  index: i
+                })
+              });
+        const targetFilePath = path.format({
           dir: this.fileObject.dir,
-          base: this._formatFileName({date: this.state.currentDate, index: i})
+          base: this._formatFileName({
+            date: this.state.currentDate,
+            index: i + 1
+          })
         });
-      const targetFilePath = i === 0 && isNextPeriod
-        ? path.format({
-          dir: this.fileObject.dir,
-          base: this._formatFileName({date: this.state.currentDate, index: 1 })
-        })
-        : path.format({
-          dir: this.fileObject.dir,
-          base: this._formatFileName({date: this.state.currentDate, index: i + 1})
-        });
-      filesToMove.push({ sourceFilePath, targetFilePath });
-    }
-    async.eachOfSeries(filesToMove, (files, idx, cb1) => {
-      debug(`src=${files.sourceFilePath}, tgt=${files.sourceFilePath}, idx=${idx}, pos=${filesToMove.length -1 -idx}`);
-      moveAndMaybeCompressFile(files.sourceFilePath, files.targetFilePath, this.options.compress && (filesToMove.length -1 -idx) === 0, cb1);
-    }, () => {
-        if (isNextPeriod) {
-          this.state.currentSize = 0;
-          this.state.currentIndex = 0;
-          this.state.currentDate = newNow();
-          debug(`rolling for next period. state=${JSON.stringify(this.state)}`);
-        } else {
-          this.state.currentSize = 0;
-          this.state.currentIndex += 1;
-          debug(`rolling during the same period. state=${JSON.stringify(this.state)}`);
-        }
-        this._renewWriteStream();
-        // wait for the file to be open before cleaning up old ones,
-        // otherwise the daysToKeep calculations can be off
-        this.currentFileStream.write('', 'utf8', () => this._clean(cb));
-      });
+        filesToMove.push({ sourceFilePath, targetFilePath });
+      }
+      debug(`filesToMove = `, filesToMove);
+      async.eachOfSeries(
+        filesToMove,
+        (files, idx, cb1) => {
+          debug(
+            `src=${files.sourceFilePath}, tgt=${
+              files.sourceFilePath
+            }, idx=${idx}, pos=${filesToMove.length - 1 - idx}`
+          );
+          moveAndMaybeCompressFile(
+            files.sourceFilePath,
+            files.targetFilePath,
+            this.options.compress && filesToMove.length - 1 - idx === 0,
+            cb1
+          );
+        },
+        finishedRolling
+      );
+    });
   }
 
-  _roll({isNextPeriod}, cb) {
+  _roll({ isNextPeriod }, cb) {
     debug(`rolling, isNextPeriod ? ${isNextPeriod}`);
     debug(`_roll: closing the current stream`);
-    this.currentFileStream.end('', this.options.encoding, () => { this._moveOldFiles(isNextPeriod, cb); });
+    this.currentFileStream.end("", this.options.encoding, () => {
+      this._moveOldFiles(isNextPeriod, cb);
+    });
   }
 
   _renewWriteStream() {
     fs.ensureDirSync(this.fileObject.dir);
-    this.justTheFile = this._formatFileName({ date: this.state.currentDate, index: this.state.index, isHotFile: true });
-    const filePath = path.format({dir: this.fileObject.dir, base: this.justTheFile});
-    const ops = _.pick(this.options, ['flags', 'encoding', 'mode']);
+    this.justTheFile = this._formatFileName({
+      date: this.state.currentDate,
+      index: 0,
+      isHotFile: true
+    });
+    const filePath = path.format({
+      dir: this.fileObject.dir,
+      base: this.justTheFile
+    });
+    const ops = _.pick(this.options, ["flags", "encoding", "mode"]);
     this.currentFileStream = fs.createWriteStream(filePath, ops);
-    this.currentFileStream.on('error', (e) => { this.emit('error', e); });
+    this.currentFileStream.on("error", e => {
+      this.emit("error", e);
+    });
   }
 
   _clean(cb) {
     this._getExistingFiles((e, existingFileDetails) => {
-      debug(`numToKeep = ${this.options.numToKeep}, existingFiles = ${existingFileDetails.length}`);
-      debug('existing files are: ', existingFileDetails);
-      if (existingFileDetails.length > this.options.numToKeep) {
+      debug(
+        `numToKeep = ${this.options.numToKeep}, existingFiles = ${existingFileDetails.length}`
+      );
+      debug("existing files are: ", existingFileDetails);
+      if (
+        this.options.numToKeep > 0 &&
+        existingFileDetails.length > this.options.numToKeep
+      ) {
         const fileNamesToRemove = _.slice(
           existingFileDetails.map(f => f.fileName),
           0,
           existingFileDetails.length - this.options.numToKeep - 1
         );
-        this._deleteFiles(fileNamesToRemove, () => {
-          this.state.currentIndex = Math.min(this.state.currentIndex, this.options.numToKeep -1);
-          cb();
-        });
+        this._deleteFiles(fileNamesToRemove, cb);
         return;
       }
       cb();
@@ -349,7 +441,7 @@ class RollingFileWriteStream extends Writable {
   _deleteFiles(fileNames, done) {
     debug(`files to delete: ${fileNames}`);
     async.each(
-      _.map(fileNames, f => path.format({ dir: this.fileObject.dir, base: f})),
+      _.map(fileNames, f => path.format({ dir: this.fileObject.dir, base: f })),
       fs.unlink,
       done
     );

--- a/test/RollingFileStream-test.js
+++ b/test/RollingFileStream-test.js
@@ -1,146 +1,158 @@
-'use strict';
+"use strict";
 
-require('should');
+require("should");
 
-var async = require('async')
-  , fs = require('fs')
-  , path = require('path')
-  , zlib = require('zlib')
-  , streams = require('stream')
-  , RollingFileStream = require('../lib').RollingFileStream;
+var async = require("async"),
+  fs = require("fs"),
+  path = require("path"),
+  zlib = require("zlib"),
+  streams = require("stream"),
+  RollingFileStream = require("../lib").RollingFileStream;
 
 function remove(filename, cb) {
-  fs.unlink(filename, function () { cb() });
+  fs.unlink(filename, function() {
+    cb();
+  });
 }
 
 function create(filename, cb) {
-  fs.writeFile(filename, 'test file', cb);
+  fs.writeFile(filename, "test file", cb);
 }
 
-describe('RollingFileStream', function () {
-
-  describe('arguments', function () {
+describe("RollingFileStream", function() {
+  describe("arguments", function() {
     var stream;
 
-    before(function (done) {
-      remove(__dirname + '/test-rolling-file-stream', function () {
-        stream = new RollingFileStream(__dirname + '/test-rolling-file-stream', 1024, 5);
+    before(function(done) {
+      remove(__dirname + "/test-rolling-file-stream", function() {
+        stream = new RollingFileStream(
+          __dirname + "/test-rolling-file-stream",
+          1024,
+          5
+        );
         done();
       });
     });
 
-    after(function (done) {
-      remove(__dirname + '/test-rolling-file-stream', done);
+    after(function(done) {
+      remove(__dirname + "/test-rolling-file-stream", done);
     });
 
-    it('should take a filename, file size (bytes), no. backups, return Writable', function () {
+    it("should take a filename, file size (bytes), no. backups, return Writable", function() {
       stream.should.be.an.instanceOf(streams.Writable);
-      stream.filename.should.eql(__dirname + '/test-rolling-file-stream');
+      stream.filename.should.eql(__dirname + "/test-rolling-file-stream");
       stream.size.should.eql(1024);
       stream.backups.should.eql(5);
     });
 
-    it('should apply default settings to the underlying stream', function () {
+    it("should apply default settings to the underlying stream", function() {
       stream.theStream.mode.should.eql(420);
-      stream.theStream.flags.should.eql('a');
+      stream.theStream.flags.should.eql("a");
     });
   });
 
-  describe('with stream arguments', function () {
-    it('should pass them to the underlying stream', function () {
+  describe("with stream arguments", function() {
+    it("should pass them to the underlying stream", function() {
       var stream = new RollingFileStream(
-        __dirname + '/test-rolling-file-stream',
+        __dirname + "/test-rolling-file-stream",
         1024,
         5,
-        {mode: parseInt('0666', 8)}
+        { mode: parseInt("0666", 8) }
       );
-      stream.theStream.mode.should.eql(parseInt('0666', 8));
+      stream.theStream.mode.should.eql(parseInt("0666", 8));
     });
 
-    after(function (done) {
-      remove(__dirname + '/test-rolling-file-stream', done);
+    after(function(done) {
+      remove(__dirname + "/test-rolling-file-stream", done);
     });
   });
 
-  describe('without size', function () {
-    it('should default to max int size', function () {
-      var stream = new RollingFileStream(__dirname + '/test-rolling-file-stream');
+  describe("without size", function() {
+    it("should default to max int size", function() {
+      var stream = new RollingFileStream(
+        __dirname + "/test-rolling-file-stream"
+      );
       stream.size.should.eql(Number.MAX_SAFE_INTEGER);
     });
 
-    after(function (done) {
-      remove(__dirname + '/test-rolling-file-stream', done);
+    after(function(done) {
+      remove(__dirname + "/test-rolling-file-stream", done);
     });
   });
 
-  describe('without number of backups', function () {
-    it('should default to 1 backup', function () {
-      var stream = new RollingFileStream(__dirname + '/test-rolling-file-stream', 1024);
+  describe("without number of backups", function() {
+    it("should default to 1 backup", function() {
+      var stream = new RollingFileStream(
+        __dirname + "/test-rolling-file-stream",
+        1024
+      );
       stream.backups.should.eql(1);
     });
 
-    after(function (done) {
-      remove(__dirname + '/test-rolling-file-stream', done);
+    after(function(done) {
+      remove(__dirname + "/test-rolling-file-stream", done);
     });
   });
 
-  describe('writing less than the file size', function () {
-
-    before(function (done) {
-      remove(__dirname + '/test-rolling-file-stream-write-less', function () {
+  describe("writing less than the file size", function() {
+    before(function(done) {
+      remove(__dirname + "/test-rolling-file-stream-write-less", function() {
         var stream = new RollingFileStream(
-          __dirname + '/test-rolling-file-stream-write-less',
+          __dirname + "/test-rolling-file-stream-write-less",
           100
         );
-        stream.write('cheese', 'utf8', function () {
+        stream.write("cheese", "utf8", function() {
           stream.end(done);
         });
       });
     });
 
-    after(function (done) {
-      remove(__dirname + '/test-rolling-file-stream-write-less', done);
+    after(function(done) {
+      remove(__dirname + "/test-rolling-file-stream-write-less", done);
     });
 
-    it('should write to the file', function (done) {
+    it("should write to the file", function(done) {
       fs.readFile(
-        __dirname + '/test-rolling-file-stream-write-less', 'utf8',
-        function (err, contents) {
-          contents.should.eql('cheese');
+        __dirname + "/test-rolling-file-stream-write-less",
+        "utf8",
+        function(err, contents) {
+          contents.should.eql("cheese");
           done(err);
         }
       );
     });
 
-    it('should write one file', function (done) {
-      fs.readdir(__dirname, function (err, files) {
-        files.filter(
-          function (file) { return file.indexOf('test-rolling-file-stream-write-less') > -1 }
-        ).should.have.length(1);
+    it("should write one file", function(done) {
+      fs.readdir(__dirname, function(err, files) {
+        files
+          .filter(function(file) {
+            return file.indexOf("test-rolling-file-stream-write-less") > -1;
+          })
+          .should.have.length(1);
         done(err);
       });
     });
   });
 
-  describe('writing more than the file size', function () {
-    before(function (done) {
+  describe("writing more than the file size", function() {
+    before(function(done) {
       async.forEach(
         [
-          __dirname + '/test-rolling-file-stream-write-more',
-          __dirname + '/test-rolling-file-stream-write-more.1'
+          __dirname + "/test-rolling-file-stream-write-more",
+          __dirname + "/test-rolling-file-stream-write-more.1"
         ],
         remove,
-        function () {
+        function() {
           var stream = new RollingFileStream(
-            __dirname + '/test-rolling-file-stream-write-more',
+            __dirname + "/test-rolling-file-stream-write-more",
             45
           );
           async.forEachSeries(
             [0, 1, 2, 3, 4, 5, 6],
-            function (i, cb) {
-              stream.write(i +'.cheese\n', 'utf8', cb);
+            function(i, cb) {
+              stream.write(i + ".cheese\n", "utf8", cb);
             },
-            function () {
+            function() {
               stream.end(done);
             }
           );
@@ -148,94 +160,110 @@ describe('RollingFileStream', function () {
       );
     });
 
-    after(function (done) {
+    after(function(done) {
       async.forEach(
         [
-          __dirname + '/test-rolling-file-stream-write-more',
-          __dirname + '/test-rolling-file-stream-write-more.1'
+          __dirname + "/test-rolling-file-stream-write-more",
+          __dirname + "/test-rolling-file-stream-write-more.1"
         ],
         remove,
         done
       );
     });
 
-    it('should write two files' , function (done) {
-      fs.readdir(__dirname, function (err, files) {
-        files.filter(
-          function (file) {
-            return file.indexOf('test-rolling-file-stream-write-more') > -1;
-          }
-        ).should.have.length(2);
+    it("should write two files", function(done) {
+      fs.readdir(__dirname, function(err, files) {
+        files
+          .filter(function(file) {
+            return file.indexOf("test-rolling-file-stream-write-more") > -1;
+          })
+          .should.have.length(2);
         done(err);
       });
     });
 
-    it('should write the last two log messages to the first file', function (done) {
+    it("should write the last two log messages to the first file", function(done) {
       fs.readFile(
-        __dirname + '/test-rolling-file-stream-write-more', 'utf8',
-        function (err, contents) {
-          contents.should.eql('5.cheese\n6.cheese\n');
-          done(err);
-        });
-    });
-
-    it('should write the first five log messages to the second file', function (done) {
-      fs.readFile(
-        __dirname + '/test-rolling-file-stream-write-more.1', 'utf8',
-        function (err, contents) {
-          contents.should.eql('0.cheese\n1.cheese\n2.cheese\n3.cheese\n4.cheese\n');
+        __dirname + "/test-rolling-file-stream-write-more",
+        "utf8",
+        function(err, contents) {
+          contents.should.eql("5.cheese\n6.cheese\n");
           done(err);
         }
       );
     });
+
+    it("should write the first five log messages to the second file", function(done) {
+      fs.readFile(
+        __dirname + "/test-rolling-file-stream-write-more.1",
+        "utf8",
+        function(err, contents) {
+          contents.should.eql(
+            "0.cheese\n1.cheese\n2.cheese\n3.cheese\n4.cheese\n"
+          );
+          done(err);
+        }
+      );
+    });
   });
 
-  describe('with options.compress = true', function () {
-    before(function (done) {
+  describe("with options.compress = true", function() {
+    before(function(done) {
       var stream = new RollingFileStream(
-        path.join(__dirname, 'compressed-backups.log'),
+        path.join(__dirname, "compressed-backups.log"),
         30, //30 bytes max size
-        2,  //two backup files to keep
-        {compress: true}
+        2, //two backup files to keep
+        { compress: true }
       );
       async.forEachSeries(
         [
-          'This is the first log message.',
-          'This is the second log message.',
-          'This is the third log message.',
-          'This is the fourth log message.'
+          "This is the first log message.",
+          "This is the second log message.",
+          "This is the third log message.",
+          "This is the fourth log message."
         ],
-        function (i, cb) {
-          stream.write(i + '\n', 'utf8', cb);
+        function(i, cb) {
+          stream.write(i + "\n", "utf8", cb);
         },
-        function () {
+        function() {
           stream.end(done);
         }
       );
     });
 
-    it('should produce three files, with the backups compressed', function (done) {
-      fs.readdir(__dirname, function (err, files) {
-        var testFiles = files.filter(
-          function (f) { return f.indexOf('compressed-backups.log') > -1 }
-        ).sort();
+    it("should produce three files, with the backups compressed", function(done) {
+      fs.readdir(__dirname, function(err, files) {
+        var testFiles = files
+          .filter(function(f) {
+            return f.indexOf("compressed-backups.log") > -1;
+          })
+          .sort();
 
         testFiles.length.should.eql(3);
         testFiles.should.eql([
-          'compressed-backups.log',
-          'compressed-backups.log.1.gz',
-          'compressed-backups.log.2.gz',
+          "compressed-backups.log",
+          "compressed-backups.log.1.gz",
+          "compressed-backups.log.2.gz"
         ]);
 
-        fs.readFile(path.join(__dirname, testFiles[0]), 'utf8', function (err, contents) {
-          contents.should.eql('This is the fourth log message.\n');
+        fs.readFile(path.join(__dirname, testFiles[0]), "utf8", function(
+          err,
+          contents
+        ) {
+          contents.should.eql("This is the fourth log message.\n");
 
-          zlib.gunzip(fs.readFileSync(path.join(__dirname, testFiles[1])),
-            function (err, contents) {
-              contents.toString('utf8').should.eql('This is the third log message.\n');
-              zlib.gunzip(fs.readFileSync(path.join(__dirname, testFiles[2])),
-                function (err, contents) {
-                  contents.toString('utf8').should.eql('This is the second log message.\n');
+          zlib.gunzip(
+            fs.readFileSync(path.join(__dirname, testFiles[1])),
+            function(err, contents) {
+              contents
+                .toString("utf8")
+                .should.eql("This is the third log message.\n");
+              zlib.gunzip(
+                fs.readFileSync(path.join(__dirname, testFiles[2])),
+                function(err, contents) {
+                  contents
+                    .toString("utf8")
+                    .should.eql("This is the second log message.\n");
                   done(err);
                 }
               );
@@ -245,184 +273,215 @@ describe('RollingFileStream', function () {
       });
     });
 
-    after(function (done) {
-      async.forEach([
-        path.join(__dirname, 'compressed-backups.log'),
-        path.join(__dirname, 'compressed-backups.log.1.gz'),
-        path.join(__dirname, 'compressed-backups.log.2.gz'),
-      ], remove, done);
-    });
-
-  });
-
-  describe('with options.keepFileExt = true', function () {
-    before(function (done) {
-      var stream = new RollingFileStream(
-        path.join(__dirname, 'extKept-backups.log'),
-        30, //30 bytes max size
-        2,  //two backup files to keep
-        {keepFileExt: true}
-      );
-      async.forEachSeries(
-        [
-          'This is the first log message.',
-          'This is the second log message.',
-          'This is the third log message.',
-          'This is the fourth log message.'
-        ],
-        function (i, cb) {
-          stream.write(i + '\n', 'utf8', cb);
-        },
-        function () {
-          stream.end(done);
-        }
-      );
-    });
-
-    it('should produce three files, with the file-extension kept', function (done) {
-      fs.readdir(__dirname, function (err, files) {
-        var testFiles = files.filter(
-          function (f) { return f.indexOf('extKept-backups') > -1 }
-        ).sort();
-
-        testFiles.length.should.eql(3);
-        testFiles.should.eql([
-          'extKept-backups.1.log',
-          'extKept-backups.2.log',
-          'extKept-backups.log',
-        ]);
-
-        fs.readFile(path.join(__dirname, testFiles[0]), 'utf8', function (err, contents) {
-          contents.should.eql('This is the third log message.\n');
-
-          fs.readFile(path.join(__dirname, testFiles[1]), 'utf8',
-            function (err, contents) {
-              contents.toString('utf8').should.eql('This is the second log message.\n');
-              fs.readFile(path.join(__dirname, testFiles[2]), 'utf8',
-                function (err, contents) {
-                  contents.toString('utf8').should.eql('This is the fourth log message.\n');
-                  done(err);
-                }
-              );
-            }
-          );
-        });
-      });
-    });
-
-    after(function (done) {
-      async.forEach([
-        path.join(__dirname, 'extKept-backups.log'),
-        path.join(__dirname, 'extKept-backups.1.log'),
-        path.join(__dirname, 'extKept-backups.2.log'),
-      ], remove, done);
-    });
-
-  });
-
-  describe('with options.compress = true and keepFileExt = true', function () {
-    before(function (done) {
-      var stream = new RollingFileStream(
-        path.join(__dirname, 'compressed-backups.log'),
-        30, //30 bytes max size
-        2,  //two backup files to keep
-        {compress: true, keepFileExt: true}
-      );
-      async.forEachSeries(
-        [
-          'This is the first log message.',
-          'This is the second log message.',
-          'This is the third log message.',
-          'This is the fourth log message.'
-        ],
-        function (i, cb) {
-          stream.write(i + '\n', 'utf8', cb);
-        },
-        function () {
-          stream.end(done);
-        }
-      );
-    });
-
-    it('should produce three files, with the backups compressed', function (done) {
-      fs.readdir(__dirname, function (err, files) {
-        var testFiles = files.filter(
-          function (f) { return f.indexOf('compressed-backups') > -1 }
-        ).sort();
-
-        testFiles.length.should.eql(3);
-        testFiles.should.eql([
-          'compressed-backups.1.log.gz',
-          'compressed-backups.2.log.gz',
-          'compressed-backups.log',
-        ]);
-
-        fs.readFile(path.join(__dirname, testFiles[2]), 'utf8', function (err, contents) {
-          contents.should.eql('This is the fourth log message.\n');
-
-          zlib.gunzip(fs.readFileSync(path.join(__dirname, testFiles[1])),
-            function (err, contents) {
-              contents.toString('utf8').should.eql('This is the second log message.\n');
-              zlib.gunzip(fs.readFileSync(path.join(__dirname, testFiles[0])),
-                function (err, contents) {
-                  contents.toString('utf8').should.eql('This is the third log message.\n');
-                  done(err);
-                }
-              );
-            }
-          );
-        });
-      });
-    });
-
-    after(function (done) {
-      async.forEach([
-        path.join(__dirname, 'compressed-backups.log'),
-        path.join(__dirname, 'compressed-backups.1.log.gz'),
-        path.join(__dirname, 'compressed-backups.2.log.gz'),
-      ], remove, done);
-    });
-
-  });
-
-  describe('when many files already exist', function () {
-    before(function (done) {
+    after(function(done) {
       async.forEach(
         [
-          __dirname + '/test-rolling-stream-with-existing-files.11',
-          __dirname + '/test-rolling-stream-with-existing-files.20',
-          __dirname + '/test-rolling-stream-with-existing-files.-1',
-          __dirname + '/test-rolling-stream-with-existing-files.1.1',
-          __dirname + '/test-rolling-stream-with-existing-files.1'
+          path.join(__dirname, "compressed-backups.log"),
+          path.join(__dirname, "compressed-backups.log.1.gz"),
+          path.join(__dirname, "compressed-backups.log.2.gz")
         ],
         remove,
-        function (err) {
+        done
+      );
+    });
+  });
+
+  describe("with options.keepFileExt = true", function() {
+    before(function(done) {
+      var stream = new RollingFileStream(
+        path.join(__dirname, "extKept-backups.log"),
+        30, //30 bytes max size
+        2, //two backup files to keep
+        { keepFileExt: true }
+      );
+      async.forEachSeries(
+        [
+          "This is the first log message.",
+          "This is the second log message.",
+          "This is the third log message.",
+          "This is the fourth log message."
+        ],
+        function(i, cb) {
+          stream.write(i + "\n", "utf8", cb);
+        },
+        function() {
+          stream.end(done);
+        }
+      );
+    });
+
+    it("should produce three files, with the file-extension kept", function(done) {
+      fs.readdir(__dirname, function(err, files) {
+        var testFiles = files
+          .filter(function(f) {
+            return f.indexOf("extKept-backups") > -1;
+          })
+          .sort();
+
+        testFiles.length.should.eql(3);
+        testFiles.should.eql([
+          "extKept-backups.1.log",
+          "extKept-backups.2.log",
+          "extKept-backups.log"
+        ]);
+
+        fs.readFile(path.join(__dirname, testFiles[0]), "utf8", function(
+          err,
+          contents
+        ) {
+          contents.should.eql("This is the third log message.\n");
+
+          fs.readFile(path.join(__dirname, testFiles[1]), "utf8", function(
+            err,
+            contents
+          ) {
+            contents
+              .toString("utf8")
+              .should.eql("This is the second log message.\n");
+            fs.readFile(path.join(__dirname, testFiles[2]), "utf8", function(
+              err,
+              contents
+            ) {
+              contents
+                .toString("utf8")
+                .should.eql("This is the fourth log message.\n");
+              done(err);
+            });
+          });
+        });
+      });
+    });
+
+    after(function(done) {
+      async.forEach(
+        [
+          path.join(__dirname, "extKept-backups.log"),
+          path.join(__dirname, "extKept-backups.1.log"),
+          path.join(__dirname, "extKept-backups.2.log")
+        ],
+        remove,
+        done
+      );
+    });
+  });
+
+  describe("with options.compress = true and keepFileExt = true", function() {
+    before(function(done) {
+      var stream = new RollingFileStream(
+        path.join(__dirname, "compressed-backups.log"),
+        30, //30 bytes max size
+        2, //two backup files to keep
+        { compress: true, keepFileExt: true }
+      );
+      async.forEachSeries(
+        [
+          "This is the first log message.",
+          "This is the second log message.",
+          "This is the third log message.",
+          "This is the fourth log message."
+        ],
+        function(i, cb) {
+          stream.write(i + "\n", "utf8", cb);
+        },
+        function() {
+          stream.end(done);
+        }
+      );
+    });
+
+    it("should produce three files, with the backups compressed", function(done) {
+      fs.readdir(__dirname, function(err, files) {
+        var testFiles = files
+          .filter(function(f) {
+            return f.indexOf("compressed-backups") > -1;
+          })
+          .sort();
+
+        testFiles.length.should.eql(3);
+        testFiles.should.eql([
+          "compressed-backups.1.log.gz",
+          "compressed-backups.2.log.gz",
+          "compressed-backups.log"
+        ]);
+
+        fs.readFile(path.join(__dirname, testFiles[2]), "utf8", function(
+          err,
+          contents
+        ) {
+          contents.should.eql("This is the fourth log message.\n");
+
+          zlib.gunzip(
+            fs.readFileSync(path.join(__dirname, testFiles[1])),
+            function(err, contents) {
+              contents
+                .toString("utf8")
+                .should.eql("This is the second log message.\n");
+              zlib.gunzip(
+                fs.readFileSync(path.join(__dirname, testFiles[0])),
+                function(err, contents) {
+                  contents
+                    .toString("utf8")
+                    .should.eql("This is the third log message.\n");
+                  done(err);
+                }
+              );
+            }
+          );
+        });
+      });
+    });
+
+    after(function(done) {
+      async.forEach(
+        [
+          path.join(__dirname, "compressed-backups.log"),
+          path.join(__dirname, "compressed-backups.1.log.gz"),
+          path.join(__dirname, "compressed-backups.2.log.gz")
+        ],
+        remove,
+        done
+      );
+    });
+  });
+
+  describe("when many files already exist", function() {
+    before(function(done) {
+      async.forEach(
+        [
+          __dirname + "/test-rolling-stream-with-existing-files.11",
+          __dirname + "/test-rolling-stream-with-existing-files.20",
+          __dirname + "/test-rolling-stream-with-existing-files.-1",
+          __dirname + "/test-rolling-stream-with-existing-files.1.1",
+          __dirname + "/test-rolling-stream-with-existing-files.1"
+        ],
+        remove,
+        function(err) {
           if (err) done(err);
 
           async.forEach(
             [
-              __dirname + '/test-rolling-stream-with-existing-files.11',
-              __dirname + '/test-rolling-stream-with-existing-files.20',
-              __dirname + '/test-rolling-stream-with-existing-files.-1',
-              __dirname + '/test-rolling-stream-with-existing-files.1.1',
-              __dirname + '/test-rolling-stream-with-existing-files.1'
+              __dirname + "/test-rolling-stream-with-existing-files.11",
+              __dirname + "/test-rolling-stream-with-existing-files.20",
+              __dirname + "/test-rolling-stream-with-existing-files.-1",
+              __dirname + "/test-rolling-stream-with-existing-files.1.1",
+              __dirname + "/test-rolling-stream-with-existing-files.1"
             ],
             create,
-            function (err) {
+            function(err) {
               if (err) done(err);
 
               var stream = new RollingFileStream(
-                __dirname + '/test-rolling-stream-with-existing-files',
+                __dirname + "/test-rolling-stream-with-existing-files",
                 18,
                 5
               );
 
               async.forEachSeries(
                 [0, 1, 2, 3, 4, 5, 6],
-                function (i, cb) {
-                  stream.write(i +'.cheese\n', 'utf8', cb);
+                function(i, cb) {
+                  stream.write(i + ".cheese\n", "utf8", cb);
                 },
-                function () {
+                function() {
                   stream.end(done);
                 }
               );
@@ -432,55 +491,65 @@ describe('RollingFileStream', function () {
       );
     });
 
-    after(function (done) {
-      async.forEach([
-        __dirname + '/test-rolling-stream-with-existing-files.-1',
-        __dirname + '/test-rolling-stream-with-existing-files',
-        __dirname + '/test-rolling-stream-with-existing-files.1.1',
-        __dirname + '/test-rolling-stream-with-existing-files.0',
-        __dirname + '/test-rolling-stream-with-existing-files.1',
-        __dirname + '/test-rolling-stream-with-existing-files.2',
-        __dirname + '/test-rolling-stream-with-existing-files.3',
-        __dirname + '/test-rolling-stream-with-existing-files.4',
-        __dirname + '/test-rolling-stream-with-existing-files.5',
-        __dirname + '/test-rolling-stream-with-existing-files.6',
-        __dirname + '/test-rolling-stream-with-existing-files.11',
-        __dirname + '/test-rolling-stream-with-existing-files.20'
-      ], remove, done);
+    after(function(done) {
+      async.forEach(
+        [
+          __dirname + "/test-rolling-stream-with-existing-files.-1",
+          __dirname + "/test-rolling-stream-with-existing-files",
+          __dirname + "/test-rolling-stream-with-existing-files.1.1",
+          __dirname + "/test-rolling-stream-with-existing-files.0",
+          __dirname + "/test-rolling-stream-with-existing-files.1",
+          __dirname + "/test-rolling-stream-with-existing-files.2",
+          __dirname + "/test-rolling-stream-with-existing-files.3",
+          __dirname + "/test-rolling-stream-with-existing-files.4",
+          __dirname + "/test-rolling-stream-with-existing-files.5",
+          __dirname + "/test-rolling-stream-with-existing-files.6",
+          __dirname + "/test-rolling-stream-with-existing-files.11",
+          __dirname + "/test-rolling-stream-with-existing-files.20"
+        ],
+        remove,
+        done
+      );
     });
 
-    it('should roll the files', function (done) {
-      fs.readdir(__dirname, function (err, files) {
-        files.should.containEql('test-rolling-stream-with-existing-files');
-        files.should.containEql('test-rolling-stream-with-existing-files.1');
-        files.should.containEql('test-rolling-stream-with-existing-files.2');
-        files.should.containEql('test-rolling-stream-with-existing-files.11');
-        files.should.containEql('test-rolling-stream-with-existing-files.20');
+    it("should roll the files, removing the highest indices", function(done) {
+      fs.readdir(__dirname, function(err, files) {
+        files.should.containEql("test-rolling-stream-with-existing-files");
+        files.should.containEql("test-rolling-stream-with-existing-files.1");
+        files.should.containEql("test-rolling-stream-with-existing-files.2");
+        files.should.containEql("test-rolling-stream-with-existing-files.3");
+        files.should.containEql("test-rolling-stream-with-existing-files.4");
         done(err);
       });
     });
   });
 
-  describe('when the directory gets deleted', function () {
+  describe("when the directory gets deleted", function() {
     var stream;
-    before(function (done) {
-      stream = new RollingFileStream(path.join('subdir', 'test-rolling-file-stream'), 5, 5);
-      stream.write('initial', 'utf8', done);
+    before(function(done) {
+      stream = new RollingFileStream(
+        path.join("subdir", "test-rolling-file-stream"),
+        5,
+        5
+      );
+      stream.write("initial", "utf8", done);
     });
 
-    after(function () {
-      fs.unlinkSync(path.join('subdir', 'test-rolling-file-stream'));
-      fs.rmdirSync('subdir');
+    after(function() {
+      fs.unlinkSync(path.join("subdir", "test-rolling-file-stream"));
+      fs.rmdirSync("subdir");
     });
 
-    it('handles directory deletion gracefully', function (done) {
-      stream.theStream.on('error', done);
+    it("handles directory deletion gracefully", function(done) {
+      stream.theStream.on("error", done);
 
-      remove(path.join('subdir', 'test-rolling-file-stream'), function () {
-        fs.rmdir('subdir', function () {
-          stream.write('rollover', 'utf8', function () {
-            fs.readFileSync(path.join('subdir', 'test-rolling-file-stream'), 'utf8')
-              .should.eql('rollover');
+      remove(path.join("subdir", "test-rolling-file-stream"), function() {
+        fs.rmdir("subdir", function() {
+          stream.write("rollover", "utf8", function() {
+            fs.readFileSync(
+              path.join("subdir", "test-rolling-file-stream"),
+              "utf8"
+            ).should.eql("rollover");
             done();
           });
         });

--- a/test/RollingFileWriteStream-test.js
+++ b/test/RollingFileWriteStream-test.js
@@ -1,30 +1,33 @@
-require('should');
+require("should");
 
-const _ = require('lodash');
-const path = require('path');
-const zlib = require('zlib');
-const async = require('async');
-const stream = require('stream');
-const fs = require('fs-extra');
-const proxyquire = require('proxyquire').noPreserveCache();
+const _ = require("lodash");
+const path = require("path");
+const zlib = require("zlib");
+const async = require("async");
+const stream = require("stream");
+const fs = require("fs-extra");
+const proxyquire = require("proxyquire").noPreserveCache();
 
 let fakeNow = new Date(2012, 8, 12, 10, 37, 11);
 const mockNow = () => fakeNow;
-const RollingFileWriteStream = proxyquire('../lib/RollingFileWriteStream', {
-  './now': mockNow
+const RollingFileWriteStream = proxyquire("../lib/RollingFileWriteStream", {
+  "./now": mockNow
 });
 let fakedFsDate = fakeNow;
-const mockFs = require('fs-extra');
-const oldStatSync = mockFs.statSync
+const mockFs = require("fs-extra");
+const oldStatSync = mockFs.statSync;
 mockFs.statSync = fd => {
   const result = oldStatSync(fd);
   result.birthtime = fakedFsDate;
   return result;
-}
+};
 
 function generateTestFile(fileName) {
-  const dirName = path.join(__dirname, 'tmp_' + Math.floor(Math.random() * new Date()));
-  fileName = fileName || 'ignored.log';
+  const dirName = path.join(
+    __dirname,
+    "tmp_" + Math.floor(Math.random() * new Date())
+  );
+  fileName = fileName || "ignored.log";
   const fileNameObj = path.parse(fileName);
   return {
     dir: dirName,
@@ -40,43 +43,50 @@ function resetTime() {
   fakedFsDate = fakeNow;
 }
 
-describe('RollingFileWriteStream', () => {
-
+describe("RollingFileWriteStream", () => {
   beforeEach(() => {
     resetTime();
   });
 
   after(() => {
-    fs
-      .readdirSync(__dirname)
-      .filter(f => f.startsWith('tmp_'))
+    fs.readdirSync(__dirname)
+      .filter(f => f.startsWith("tmp_"))
       .forEach(f => fs.removeSync(path.join(__dirname, f)));
   });
 
-  describe('with no arguments', () => {
-    it('should throw an error', () => {
+  describe("with no arguments", () => {
+    it("should throw an error", () => {
       (() => new RollingFileWriteStream()).should.throw(
-        /(the )?"?path"? (argument )?must be (a|of type) string\. received (type )?undefined/i);
+        /(the )?"?path"? (argument )?must be (a|of type) string\. received (type )?undefined/i
+      );
     });
   });
 
-  describe('with invalid options', () => {
+  describe("with invalid options", () => {
     after(done => {
-      fs.remove('filename', done);
+      fs.remove("filename", done);
     });
 
-    it('should complain about a negative maxSize', () => {
-      (() => { new RollingFileWriteStream('filename', { maxSize: -3 }) }).should.throw('options.maxSize (-3) should be > 0');
-      (() => { new RollingFileWriteStream('filename', { maxSize: 0 }) }).should.throw('options.maxSize (0) should be > 0');
+    it("should complain about a negative maxSize", () => {
+      (() => {
+        new RollingFileWriteStream("filename", { maxSize: -3 });
+      }).should.throw("options.maxSize (-3) should be > 0");
+      (() => {
+        new RollingFileWriteStream("filename", { maxSize: 0 });
+      }).should.throw("options.maxSize (0) should be > 0");
     });
 
-    it('should complain about a negative numToKeep', () => {
-      (() => { new RollingFileWriteStream('filename', { numToKeep: -3 }) }).should.throw('options.numToKeep (-3) should be > 0');
-      (() => { new RollingFileWriteStream('filename', { numToKeep: 0 }) }).should.throw('options.numToKeep (0) should be > 0');
+    it("should complain about a negative numToKeep", () => {
+      (() => {
+        new RollingFileWriteStream("filename", { numToKeep: -3 });
+      }).should.throw("options.numToKeep (-3) should be > 0");
+      (() => {
+        new RollingFileWriteStream("filename", { numToKeep: 0 });
+      }).should.throw("options.numToKeep (0) should be > 0");
     });
   });
 
-  describe('with default arguments', () => {
+  describe("with default arguments", () => {
     const fileObj = generateTestFile();
     let s;
 
@@ -89,33 +99,36 @@ describe('RollingFileWriteStream', () => {
       fs.removeSync(fileObj.dir);
     });
 
-    it('should take a filename and options, return Writable', () => {
+    it("should take a filename and options, return Writable", () => {
       s.should.be.an.instanceOf(stream.Writable);
       s.currentFileStream.path.should.eql(fileObj.path);
       s.currentFileStream.mode.should.eql(420);
-      s.currentFileStream.flags.should.eql('a');
+      s.currentFileStream.flags.should.eql("a");
     });
 
-    it('should apply default options', () => {
+    it("should apply default options", () => {
       s.options.maxSize.should.eql(Number.MAX_SAFE_INTEGER);
-      s.options.encoding.should.eql('utf8');
+      s.options.encoding.should.eql("utf8");
       s.options.mode.should.eql(420);
-      s.options.flags.should.eql('a');
+      s.options.flags.should.eql("a");
       s.options.compress.should.eql(false);
       s.options.keepFileExt.should.eql(false);
     });
   });
 
-  describe('with 5 maxSize, rotating daily', () => {
-    const fileObj = generateTestFile('noExtension');
+  describe("with 5 maxSize, rotating daily", () => {
+    const fileObj = generateTestFile("noExtension");
     let s;
 
     before(done => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
-      s = new RollingFileWriteStream(fileObj.path, { pattern: 'yyyy-MM-dd', maxSize: 5 });
+      s = new RollingFileWriteStream(fileObj.path, {
+        pattern: "yyyy-MM-dd",
+        maxSize: 5
+      });
       const flows = Array.from(Array(38).keys()).map(i => cb => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5, 10), 10, 37, 11);
-        s.write(i.toString(), 'utf8', cb);
+        s.write(i.toString(), "utf8", cb);
       });
       async.waterfall(flows, () => done());
     });
@@ -125,75 +138,149 @@ describe('RollingFileWriteStream', () => {
       done();
     });
 
-    it('should rotate using filename with no extension', () => {
+    it("should rotate using filename with no extension", () => {
       const files = fs.readdirSync(fileObj.dir);
       const expectedFileList = [
         fileObj.base, //353637
-        fileObj.base + '.2012-09-12.1', // 01234
-        fileObj.base + '.2012-09-13.1', // 56789
-        fileObj.base + '.2012-09-14.2', // 101112
-        fileObj.base + '.2012-09-14.1', // 1314
-        fileObj.base + '.2012-09-15.2', // 151617
-        fileObj.base + '.2012-09-15.1', // 1819
-        fileObj.base + '.2012-09-16.2', // 202122
-        fileObj.base + '.2012-09-16.1', // 2324
-        fileObj.base + '.2012-09-17.2', // 252627
-        fileObj.base + '.2012-09-17.1', // 2829
-        fileObj.base + '.2012-09-18.2', // 303132
-        fileObj.base + '.2012-09-18.1'  // 3334
+        fileObj.base + ".2012-09-12.1", // 01234
+        fileObj.base + ".2012-09-13.1", // 56789
+        fileObj.base + ".2012-09-14.2", // 101112
+        fileObj.base + ".2012-09-14.1", // 1314
+        fileObj.base + ".2012-09-15.2", // 151617
+        fileObj.base + ".2012-09-15.1", // 1819
+        fileObj.base + ".2012-09-16.2", // 202122
+        fileObj.base + ".2012-09-16.1", // 2324
+        fileObj.base + ".2012-09-17.2", // 252627
+        fileObj.base + ".2012-09-17.1", // 2829
+        fileObj.base + ".2012-09-18.2", // 303132
+        fileObj.base + ".2012-09-18.1" // 3334
       ];
-      files.length.should.equal(expectedFileList.length);
       files.should.containDeep(expectedFileList);
-      fs.readFileSync(path.format(fileObj)).toString().should.equal('353637');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-12.1',
-      }))).toString().should.equal('01234');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-13.1',
-      }))).toString().should.equal('56789');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-14.2',
-      }))).toString().should.equal('101112');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-14.1',
-      }))).toString().should.equal('1314');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-15.2',
-      }))).toString().should.equal('151617');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-15.1',
-      }))).toString().should.equal('1819');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-16.2',
-      }))).toString().should.equal('202122');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-16.1',
-      }))).toString().should.equal('2324');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-17.2',
-      }))).toString().should.equal('252627');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-17.1',
-      }))).toString().should.equal('2829');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-18.2',
-      }))).toString().should.equal('303132');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-18.1',
-      }))).toString().should.equal('3334');
+      files.length.should.equal(expectedFileList.length);
+      fs.readFileSync(path.format(fileObj))
+        .toString()
+        .should.equal("353637");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-12.1"
+          })
+        )
+      )
+        .toString()
+        .should.equal("01234");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-13.1"
+          })
+        )
+      )
+        .toString()
+        .should.equal("56789");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-14.2"
+          })
+        )
+      )
+        .toString()
+        .should.equal("101112");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-14.1"
+          })
+        )
+      )
+        .toString()
+        .should.equal("1314");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-15.2"
+          })
+        )
+      )
+        .toString()
+        .should.equal("151617");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-15.1"
+          })
+        )
+      )
+        .toString()
+        .should.equal("1819");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-16.2"
+          })
+        )
+      )
+        .toString()
+        .should.equal("202122");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-16.1"
+          })
+        )
+      )
+        .toString()
+        .should.equal("2324");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-17.2"
+          })
+        )
+      )
+        .toString()
+        .should.equal("252627");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-17.1"
+          })
+        )
+      )
+        .toString()
+        .should.equal("2829");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-18.2"
+          })
+        )
+      )
+        .toString()
+        .should.equal("303132");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-18.1"
+          })
+        )
+      )
+        .toString()
+        .should.equal("3334");
     });
   });
 
-  describe('with default arguments and recreated in the same day', () => {
+  describe("with default arguments and recreated in the same day", () => {
     const fileObj = generateTestFile();
     let s;
 
     before(done => {
       const flows = Array.from(Array(3).keys()).map(() => cb => {
         s = new RollingFileWriteStream(fileObj.path);
-        s.write('abc', 'utf8', cb);
+        s.write("abc", "utf8", cb);
         s.end();
-      })
+      });
       async.waterfall(flows, () => done());
     });
 
@@ -201,28 +288,36 @@ describe('RollingFileWriteStream', () => {
       fs.removeSync(fileObj.dir);
     });
 
-    it('should have only 1 file', () => {
+    it("should have only 1 file", () => {
       const files = fs.readdirSync(fileObj.dir);
       const expectedFileList = [fileObj.base];
-      files.length.should.equal(expectedFileList.length);
       files.should.containDeep(expectedFileList);
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base,
-      }))).toString().should.equal('abcabcabc');
+      files.length.should.equal(expectedFileList.length);
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base
+          })
+        )
+      )
+        .toString()
+        .should.equal("abcabcabc");
     });
-
   });
 
-  describe('with 5 maxSize, using filename with extension', () => {
+  describe("with 5 maxSize, using filename with extension", () => {
     const fileObj = generateTestFile("withExtension.log");
     let s;
 
     before(done => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
-      s = new RollingFileWriteStream(fileObj.path, { pattern: 'yyyy-MM-dd', maxSize: 5 });
+      s = new RollingFileWriteStream(fileObj.path, {
+        pattern: "yyyy-MM-dd",
+        maxSize: 5
+      });
       const flows = Array.from(Array(38).keys()).map(i => cb => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 10, 10), 10, 37, 11);
-        s.write(i.toString(), 'utf8', cb);
+        s.write(i.toString(), "utf8", cb);
       });
       async.waterfall(flows, () => done());
     });
@@ -232,66 +327,140 @@ describe('RollingFileWriteStream', () => {
       done();
     });
 
-    it('should rotate files within the day, and when the day changes', () => {
+    it("should rotate files within the day, and when the day changes", () => {
       const files = fs.readdirSync(fileObj.dir);
       const expectedFileList = [
         fileObj.base, //3637
-        fileObj.base + '.2012-09-12.2', //01234
-        fileObj.base + '.2012-09-12.1', //56789
-        fileObj.base + '.2012-09-13.4', //101112
-        fileObj.base + '.2012-09-13.3', //131415
-        fileObj.base + '.2012-09-13.2', //161718
-        fileObj.base + '.2012-09-13.1', //19
-        fileObj.base + '.2012-09-14.4', //202122
-        fileObj.base + '.2012-09-14.3', //232425
-        fileObj.base + '.2012-09-14.2', //262728
-        fileObj.base + '.2012-09-14.1', //29
-        fileObj.base + '.2012-09-15.2', //303132
-        fileObj.base + '.2012-09-15.1', //333435
+        fileObj.base + ".2012-09-12.2", //01234
+        fileObj.base + ".2012-09-12.1", //56789
+        fileObj.base + ".2012-09-13.4", //101112
+        fileObj.base + ".2012-09-13.3", //131415
+        fileObj.base + ".2012-09-13.2", //161718
+        fileObj.base + ".2012-09-13.1", //19
+        fileObj.base + ".2012-09-14.4", //202122
+        fileObj.base + ".2012-09-14.3", //232425
+        fileObj.base + ".2012-09-14.2", //262728
+        fileObj.base + ".2012-09-14.1", //29
+        fileObj.base + ".2012-09-15.2", //303132
+        fileObj.base + ".2012-09-15.1" //333435
       ];
-      files.length.should.equal(expectedFileList.length);
       files.should.containDeep(expectedFileList);
-      fs.readFileSync(path.format(fileObj)).toString().should.equal('3637');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-12.2',
-      }))).toString().should.equal('01234');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-12.1',
-      }))).toString().should.equal('56789');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-13.4',
-      }))).toString().should.equal('101112');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-13.3',
-      }))).toString().should.equal('131415');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-13.2',
-      }))).toString().should.equal('161718');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-13.1',
-      }))).toString().should.equal('19');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-14.4',
-      }))).toString().should.equal('202122');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-14.3',
-      }))).toString().should.equal('232425');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-14.2',
-      }))).toString().should.equal('262728');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-14.1',
-      }))).toString().should.equal('29');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-15.2',
-      }))).toString().should.equal('303132');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-15.1',
-      }))).toString().should.equal('333435');
+      files.length.should.equal(expectedFileList.length);
+      fs.readFileSync(path.format(fileObj))
+        .toString()
+        .should.equal("3637");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-12.2"
+          })
+        )
+      )
+        .toString()
+        .should.equal("01234");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-12.1"
+          })
+        )
+      )
+        .toString()
+        .should.equal("56789");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-13.4"
+          })
+        )
+      )
+        .toString()
+        .should.equal("101112");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-13.3"
+          })
+        )
+      )
+        .toString()
+        .should.equal("131415");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-13.2"
+          })
+        )
+      )
+        .toString()
+        .should.equal("161718");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-13.1"
+          })
+        )
+      )
+        .toString()
+        .should.equal("19");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-14.4"
+          })
+        )
+      )
+        .toString()
+        .should.equal("202122");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-14.3"
+          })
+        )
+      )
+        .toString()
+        .should.equal("232425");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-14.2"
+          })
+        )
+      )
+        .toString()
+        .should.equal("262728");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-14.1"
+          })
+        )
+      )
+        .toString()
+        .should.equal("29");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-15.2"
+          })
+        )
+      )
+        .toString()
+        .should.equal("303132");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-15.1"
+          })
+        )
+      )
+        .toString()
+        .should.equal("333435");
     });
   });
 
-  describe('with 5 maxSize and 3 files limit', () => {
+  describe("with 5 maxSize and 3 files limit", () => {
     const fileObj = generateTestFile();
     let s;
 
@@ -303,7 +472,7 @@ describe('RollingFileWriteStream', () => {
       });
       const flows = Array.from(Array(38).keys()).map(i => cb => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5), 10, 37, 11);
-        s.write(i.toString(), 'utf8', cb);
+        s.write(i.toString(), "utf8", cb);
       });
       async.waterfall(flows, () => done());
     });
@@ -313,30 +482,50 @@ describe('RollingFileWriteStream', () => {
       fs.removeSync(fileObj.dir);
     });
 
-    it('should rotate with at most 3 backup files not including the hot one', () => {
+    it("should rotate with at most 3 backup files not including the hot one", () => {
       const files = fs.readdirSync(fileObj.dir);
       const expectedFileList = [
         fileObj.base,
-        fileObj.base + '.1',
-        fileObj.base + '.2',
-        fileObj.base + '.3'
+        fileObj.base + ".1",
+        fileObj.base + ".2",
+        fileObj.base + ".3"
       ];
-      files.length.should.equal(expectedFileList.length);
       files.should.containDeep(expectedFileList);
-      fs.readFileSync(path.format(fileObj)).toString().should.equal('37');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.1'
-      }))).toString().should.equal('343536');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2'
-      }))).toString().should.equal('313233');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.3'
-      }))).toString().should.equal('282930');
+      files.length.should.equal(expectedFileList.length);
+      fs.readFileSync(path.format(fileObj))
+        .toString()
+        .should.equal("37");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".1"
+          })
+        )
+      )
+        .toString()
+        .should.equal("343536");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2"
+          })
+        )
+      )
+        .toString()
+        .should.equal("313233");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".3"
+          })
+        )
+      )
+        .toString()
+        .should.equal("282930");
     });
   });
 
-  describe('with 5 maxSize and 3 files limit, rotating daily', () => {
+  describe("with 5 maxSize and 3 files limit, rotating daily", () => {
     const fileObj = generateTestFile();
     let s;
 
@@ -344,12 +533,12 @@ describe('RollingFileWriteStream', () => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
         maxSize: 5,
-        pattern: 'yyyy-MM-dd',
+        pattern: "yyyy-MM-dd",
         numToKeep: 3
       });
       const flows = Array.from(Array(38).keys()).map(i => cb => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 10), 10, 37, 11);
-        s.write(i.toString(), 'utf8', cb);
+        s.write(i.toString(), "utf8", cb);
       });
       async.waterfall(flows, () => done());
     });
@@ -359,30 +548,50 @@ describe('RollingFileWriteStream', () => {
       fs.removeSync(fileObj.dir);
     });
 
-    it('should rotate with at most 3 backup files not including the hot one', () => {
+    it("should rotate with at most 3 backup files not including the hot one", () => {
       const files = fs.readdirSync(fileObj.dir);
       const expectedFileList = [
         fileObj.base, //3637
-        fileObj.base + '.2012-09-14.1', //29
-        fileObj.base + '.2012-09-15.2', //303132
-        fileObj.base + '.2012-09-15.1', //333435
+        fileObj.base + ".2012-09-14.1", //29
+        fileObj.base + ".2012-09-15.2", //303132
+        fileObj.base + ".2012-09-15.1" //333435
       ];
-      files.length.should.equal(expectedFileList.length);
       files.should.containDeep(expectedFileList);
-      fs.readFileSync(path.format(fileObj)).toString().should.equal('3637');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-15.1',
-      }))).toString().should.equal('333435');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-15.2',
-      }))).toString().should.equal('303132');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-14.1',
-      }))).toString().should.equal('29');
+      files.length.should.equal(expectedFileList.length);
+      fs.readFileSync(path.format(fileObj))
+        .toString()
+        .should.equal("3637");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-15.1"
+          })
+        )
+      )
+        .toString()
+        .should.equal("333435");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-15.2"
+          })
+        )
+      )
+        .toString()
+        .should.equal("303132");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-14.1"
+          })
+        )
+      )
+        .toString()
+        .should.equal("29");
     });
   });
 
-  describe('with date pattern dd-MM-yyyy', () => {
+  describe("with date pattern dd-MM-yyyy", () => {
     const fileObj = generateTestFile();
     let s;
 
@@ -390,37 +599,42 @@ describe('RollingFileWriteStream', () => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
         maxSize: 5,
-        pattern: 'dd-MM-yyyy'
+        pattern: "dd-MM-yyyy"
       });
       const flows = Array.from(Array(8).keys()).map(i => cb => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5, 10), 10, 37, 11);
-        s.write(i.toString(), 'utf8', cb);
+        s.write(i.toString(), "utf8", cb);
       });
       async.waterfall(flows, () => done());
     });
 
-    after((done) => {
+    after(done => {
       s.end(() => {
         fs.remove(fileObj.dir, done);
       });
     });
 
-    it('should rotate with date pattern dd-MM-yyyy in the file name', () => {
+    it("should rotate with date pattern dd-MM-yyyy in the file name", () => {
       const files = fs.readdirSync(fileObj.dir);
-      const expectedFileList = [
-        fileObj.base,
-        fileObj.base + '.12-09-2012.1'
-      ];
-      files.length.should.equal(expectedFileList.length);
+      const expectedFileList = [fileObj.base, fileObj.base + ".12-09-2012.1"];
       files.should.containDeep(expectedFileList);
-      fs.readFileSync(path.format(fileObj)).toString().should.equal('567');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.12-09-2012.1'
-      }))).toString().should.equal('01234');
+      files.length.should.equal(expectedFileList.length);
+      fs.readFileSync(path.format(fileObj))
+        .toString()
+        .should.equal("567");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".12-09-2012.1"
+          })
+        )
+      )
+        .toString()
+        .should.equal("01234");
     });
   });
 
-  describe('with compress true', () => {
+  describe("with compress true", () => {
     const fileObj = generateTestFile();
     let s;
 
@@ -428,12 +642,12 @@ describe('RollingFileWriteStream', () => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
         maxSize: 5,
-        pattern: 'yyyy-MM-dd',
+        pattern: "yyyy-MM-dd",
         compress: true
       });
       const flows = Array.from(Array(8).keys()).map(i => cb => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5, 10), 10, 37, 11);
-        s.write(i.toString(), 'utf8', cb);
+        s.write(i.toString(), "utf8", cb);
       });
       async.waterfall(flows, () => done());
     });
@@ -443,37 +657,46 @@ describe('RollingFileWriteStream', () => {
       fs.removeSync(fileObj.dir);
     });
 
-    it('should rotate with gunzip', () => {
+    it("should rotate with gunzip", () => {
       const files = fs.readdirSync(fileObj.dir);
       const expectedFileList = [
         fileObj.base,
-        fileObj.base + '.2012-09-12.1.gz'
+        fileObj.base + ".2012-09-12.1.gz"
       ];
-      files.length.should.equal(expectedFileList.length);
       files.should.containDeep(expectedFileList);
+      files.length.should.equal(expectedFileList.length);
 
-      fs.readFileSync(path.format(fileObj)).toString().should.equal('567');
-      const content = fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.base + '.2012-09-12.1.gz'
-      })));
-      zlib.gunzipSync(content).toString().should.equal('01234');
+      fs.readFileSync(path.format(fileObj))
+        .toString()
+        .should.equal("567");
+      const content = fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.base + ".2012-09-12.1.gz"
+          })
+        )
+      );
+      zlib
+        .gunzipSync(content)
+        .toString()
+        .should.equal("01234");
     });
   });
 
-  describe('with keepFileExt', () => {
-    const fileObj = generateTestFile('keepFileExt.log');
+  describe("with keepFileExt", () => {
+    const fileObj = generateTestFile("keepFileExt.log");
     let s;
 
     before(done => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
-        pattern: 'yyyy-MM-dd',
+        pattern: "yyyy-MM-dd",
         maxSize: 5,
         keepFileExt: true
       });
       const flows = Array.from(Array(8).keys()).map(i => cb => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5, 10), 10, 37, 11);
-        s.write(i.toString(), 'utf8', cb);
+        s.write(i.toString(), "utf8", cb);
       });
       async.waterfall(flows, () => done());
     });
@@ -484,38 +707,44 @@ describe('RollingFileWriteStream', () => {
       done();
     });
 
-    it('should rotate with the same extension', () => {
+    it("should rotate with the same extension", () => {
       const files = fs.readdirSync(fileObj.dir);
       const expectedFileList = [
         fileObj.base,
-        fileObj.name + '.2012-09-12.1.log'
+        fileObj.name + ".2012-09-12.1.log"
       ];
-      files.length.should.equal(expectedFileList.length);
       files.should.containDeep(expectedFileList);
+      files.length.should.equal(expectedFileList.length);
 
-      fs.readFileSync(path.format(fileObj)).toString().should.equal('567');
-      fs.readFileSync(path.format({
-        dir: fileObj.dir,
-        base: fileObj.name + '.2012-09-12.1' + fileObj.ext
-      })).toString().should.equal('01234');
+      fs.readFileSync(path.format(fileObj))
+        .toString()
+        .should.equal("567");
+      fs.readFileSync(
+        path.format({
+          dir: fileObj.dir,
+          base: fileObj.name + ".2012-09-12.1" + fileObj.ext
+        })
+      )
+        .toString()
+        .should.equal("01234");
     });
   });
 
-  describe('with keepFileExt and compress', () => {
-    const fileObj = generateTestFile('keepFileExt.log');
+  describe("with keepFileExt and compress", () => {
+    const fileObj = generateTestFile("keepFileExt.log");
     let s;
 
     before(done => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
         maxSize: 5,
-        pattern: 'yyyy-MM-dd',
+        pattern: "yyyy-MM-dd",
         keepFileExt: true,
         compress: true
       });
       const flows = Array.from(Array(8).keys()).map(i => cb => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5, 10), 10, 37, 11);
-        s.write(i.toString(), 'utf8', cb);
+        s.write(i.toString(), "utf8", cb);
       });
       async.waterfall(flows, () => done());
     });
@@ -526,38 +755,47 @@ describe('RollingFileWriteStream', () => {
       done();
     });
 
-    it('should rotate with the same extension', () => {
+    it("should rotate with the same extension", () => {
       const files = fs.readdirSync(fileObj.dir);
       const expectedFileList = [
         fileObj.base,
-        fileObj.name + '.2012-09-12.1.log.gz'
+        fileObj.name + ".2012-09-12.1.log.gz"
       ];
-      files.length.should.equal(expectedFileList.length);
       files.should.containDeep(expectedFileList);
+      files.length.should.equal(expectedFileList.length);
 
-      fs.readFileSync(path.format(fileObj)).toString().should.equal('567');
-      const content = fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-12.1.log.gz'
-      })));
-      zlib.gunzipSync(content).toString().should.equal('01234');
+      fs.readFileSync(path.format(fileObj))
+        .toString()
+        .should.equal("567");
+      const content = fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.name + ".2012-09-12.1.log.gz"
+          })
+        )
+      );
+      zlib
+        .gunzipSync(content)
+        .toString()
+        .should.equal("01234");
     });
   });
 
-  describe('with alwaysIncludePattern and keepFileExt', () => {
-    const fileObj = generateTestFile('keepFileExt.log');
+  describe("with alwaysIncludePattern and keepFileExt", () => {
+    const fileObj = generateTestFile("keepFileExt.log");
     let s;
 
     before(done => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
         maxSize: 5,
-        pattern: 'yyyy-MM-dd',
+        pattern: "yyyy-MM-dd",
         keepFileExt: true,
         alwaysIncludePattern: true
       });
       const flows = Array.from(Array(8).keys()).map(i => cb => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5, 10), 10, 37, 11);
-        s.write(i.toString(), 'utf8', cb);
+        s.write(i.toString(), "utf8", cb);
       });
       async.waterfall(flows, () => done());
     });
@@ -568,25 +806,37 @@ describe('RollingFileWriteStream', () => {
       done();
     });
 
-    it('should rotate with the same extension and keep date in the filename', () => {
+    it("should rotate with the same extension and keep date in the filename", () => {
       const files = fs.readdirSync(fileObj.dir);
       const expectedFileList = [
-        fileObj.name + '.2012-09-12.1.log',
-        fileObj.name + '.2012-09-13.log'
+        fileObj.name + ".2012-09-12.1.log",
+        fileObj.name + ".2012-09-13.log"
       ];
-      files.length.should.equal(expectedFileList.length);
       files.should.containDeep(expectedFileList);
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-13.log'
-      }))).toString().should.equal('567');
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-12.1.log'
-      }))).toString().should.equal('01234');
+      files.length.should.equal(expectedFileList.length);
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.name + ".2012-09-13.log"
+          })
+        )
+      )
+        .toString()
+        .should.equal("567");
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.name + ".2012-09-12.1.log"
+          })
+        )
+      )
+        .toString()
+        .should.equal("01234");
     });
   });
 
-  describe('with 5 maxSize, compress, keepFileExt and alwaysIncludePattern', () => {
-    const fileObj = generateTestFile('keepFileExt.log');
+  describe("with 5 maxSize, compress, keepFileExt and alwaysIncludePattern", () => {
+    const fileObj = generateTestFile("keepFileExt.log");
     let s;
 
     before(done => {
@@ -596,11 +846,11 @@ describe('RollingFileWriteStream', () => {
         compress: true,
         keepFileExt: true,
         alwaysIncludePattern: true,
-        pattern: 'yyyy-MM-dd'
+        pattern: "yyyy-MM-dd"
       });
       const flows = Array.from(Array(38).keys()).map(i => cb => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5, 10), 10, 37, 11);
-        s.write(i.toString(), 'utf8', cb);
+        s.write(i.toString(), "utf8", cb);
       });
       async.waterfall(flows, () => done());
     });
@@ -611,77 +861,191 @@ describe('RollingFileWriteStream', () => {
       done();
     });
 
-    it('should rotate every day', () => {
+    it("should rotate every day", () => {
       const files = fs.readdirSync(fileObj.dir);
       const expectedFileList = [
-        fileObj.name + '.2012-09-12.1.log.gz', //01234
-        fileObj.name + '.2012-09-13.1.log.gz', //56789
-        fileObj.name + '.2012-09-14.2.log.gz', //101112
-        fileObj.name + '.2012-09-14.1.log.gz', //1314
-        fileObj.name + '.2012-09-15.2.log.gz', //151617
-        fileObj.name + '.2012-09-15.1.log.gz', //1819
-        fileObj.name + '.2012-09-16.2.log.gz', //202122
-        fileObj.name + '.2012-09-16.1.log.gz', //2324
-        fileObj.name + '.2012-09-17.2.log.gz', //252627
-        fileObj.name + '.2012-09-17.1.log.gz', //2829
-        fileObj.name + '.2012-09-18.2.log.gz', //303132
-        fileObj.name + '.2012-09-18.1.log.gz', //3334
-        fileObj.name + '.2012-09-19.log' //353637
+        fileObj.name + ".2012-09-12.1.log.gz", //01234
+        fileObj.name + ".2012-09-13.1.log.gz", //56789
+        fileObj.name + ".2012-09-14.2.log.gz", //101112
+        fileObj.name + ".2012-09-14.1.log.gz", //1314
+        fileObj.name + ".2012-09-15.2.log.gz", //151617
+        fileObj.name + ".2012-09-15.1.log.gz", //1819
+        fileObj.name + ".2012-09-16.2.log.gz", //202122
+        fileObj.name + ".2012-09-16.1.log.gz", //2324
+        fileObj.name + ".2012-09-17.2.log.gz", //252627
+        fileObj.name + ".2012-09-17.1.log.gz", //2829
+        fileObj.name + ".2012-09-18.2.log.gz", //303132
+        fileObj.name + ".2012-09-18.1.log.gz", //3334
+        fileObj.name + ".2012-09-19.log" //353637
       ];
-      files.length.should.equal(expectedFileList.length);
       files.should.containDeep(expectedFileList);
-      fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-19.log',
-      }))).toString().should.equal('353637');
-      zlib.gunzipSync(fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-18.1.log.gz',
-      })))).toString().should.equal('3334');
-      zlib.gunzipSync(fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-18.2.log.gz',
-      })))).toString().should.equal('303132');
-      zlib.gunzipSync(fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-17.1.log.gz',
-      })))).toString().should.equal('2829');
-      zlib.gunzipSync(fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-17.2.log.gz',
-      })))).toString().should.equal('252627');
-      zlib.gunzipSync(fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-16.1.log.gz',
-      })))).toString().should.equal('2324');
-      zlib.gunzipSync(fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-16.2.log.gz',
-      })))).toString().should.equal('202122');
-      zlib.gunzipSync(fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-15.1.log.gz',
-      })))).toString().should.equal('1819');
-      zlib.gunzipSync(fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-15.2.log.gz',
-      })))).toString().should.equal('151617');
-      zlib.gunzipSync(fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-14.1.log.gz',
-      })))).toString().should.equal('1314');
-      zlib.gunzipSync(fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-14.2.log.gz',
-      })))).toString().should.equal('101112');
-      zlib.gunzipSync(fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-13.1.log.gz',
-      })))).toString().should.equal('56789');
-      zlib.gunzipSync(fs.readFileSync(path.format(_.assign({}, fileObj, {
-        base: fileObj.name + '.2012-09-12.1.log.gz',
-      })))).toString().should.equal('01234');
+      files.length.should.equal(expectedFileList.length);
+      fs.readFileSync(
+        path.format(
+          _.assign({}, fileObj, {
+            base: fileObj.name + ".2012-09-19.log"
+          })
+        )
+      )
+        .toString()
+        .should.equal("353637");
+      zlib
+        .gunzipSync(
+          fs.readFileSync(
+            path.format(
+              _.assign({}, fileObj, {
+                base: fileObj.name + ".2012-09-18.1.log.gz"
+              })
+            )
+          )
+        )
+        .toString()
+        .should.equal("3334");
+      zlib
+        .gunzipSync(
+          fs.readFileSync(
+            path.format(
+              _.assign({}, fileObj, {
+                base: fileObj.name + ".2012-09-18.2.log.gz"
+              })
+            )
+          )
+        )
+        .toString()
+        .should.equal("303132");
+      zlib
+        .gunzipSync(
+          fs.readFileSync(
+            path.format(
+              _.assign({}, fileObj, {
+                base: fileObj.name + ".2012-09-17.1.log.gz"
+              })
+            )
+          )
+        )
+        .toString()
+        .should.equal("2829");
+      zlib
+        .gunzipSync(
+          fs.readFileSync(
+            path.format(
+              _.assign({}, fileObj, {
+                base: fileObj.name + ".2012-09-17.2.log.gz"
+              })
+            )
+          )
+        )
+        .toString()
+        .should.equal("252627");
+      zlib
+        .gunzipSync(
+          fs.readFileSync(
+            path.format(
+              _.assign({}, fileObj, {
+                base: fileObj.name + ".2012-09-16.1.log.gz"
+              })
+            )
+          )
+        )
+        .toString()
+        .should.equal("2324");
+      zlib
+        .gunzipSync(
+          fs.readFileSync(
+            path.format(
+              _.assign({}, fileObj, {
+                base: fileObj.name + ".2012-09-16.2.log.gz"
+              })
+            )
+          )
+        )
+        .toString()
+        .should.equal("202122");
+      zlib
+        .gunzipSync(
+          fs.readFileSync(
+            path.format(
+              _.assign({}, fileObj, {
+                base: fileObj.name + ".2012-09-15.1.log.gz"
+              })
+            )
+          )
+        )
+        .toString()
+        .should.equal("1819");
+      zlib
+        .gunzipSync(
+          fs.readFileSync(
+            path.format(
+              _.assign({}, fileObj, {
+                base: fileObj.name + ".2012-09-15.2.log.gz"
+              })
+            )
+          )
+        )
+        .toString()
+        .should.equal("151617");
+      zlib
+        .gunzipSync(
+          fs.readFileSync(
+            path.format(
+              _.assign({}, fileObj, {
+                base: fileObj.name + ".2012-09-14.1.log.gz"
+              })
+            )
+          )
+        )
+        .toString()
+        .should.equal("1314");
+      zlib
+        .gunzipSync(
+          fs.readFileSync(
+            path.format(
+              _.assign({}, fileObj, {
+                base: fileObj.name + ".2012-09-14.2.log.gz"
+              })
+            )
+          )
+        )
+        .toString()
+        .should.equal("101112");
+      zlib
+        .gunzipSync(
+          fs.readFileSync(
+            path.format(
+              _.assign({}, fileObj, {
+                base: fileObj.name + ".2012-09-13.1.log.gz"
+              })
+            )
+          )
+        )
+        .toString()
+        .should.equal("56789");
+      zlib
+        .gunzipSync(
+          fs.readFileSync(
+            path.format(
+              _.assign({}, fileObj, {
+                base: fileObj.name + ".2012-09-12.1.log.gz"
+              })
+            )
+          )
+        )
+        .toString()
+        .should.equal("01234");
     });
   });
 
-  describe('when old files exist', () => {
+  describe("when old files exist", () => {
     const fileObj = generateTestFile();
     let s;
 
     before(done => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       fs.ensureFileSync(fileObj.path);
-      fs.writeFileSync(fileObj.path, 'exist');
+      fs.writeFileSync(fileObj.path, "exist");
       s = new RollingFileWriteStream(fileObj.path);
-      s.write('now', 'utf8', done);
+      s.write("now", "utf8", done);
     });
 
     after(() => {
@@ -689,28 +1053,30 @@ describe('RollingFileWriteStream', () => {
       fs.removeSync(fileObj.dir);
     });
 
-    it('should use write in the old file if not reach the maxSize limit', () => {
+    it("should use write in the old file if not reach the maxSize limit", () => {
       const files = fs.readdirSync(fileObj.dir);
       const expectedFileList = [fileObj.base];
-      files.length.should.equal(expectedFileList.length);
       files.should.containDeep(expectedFileList);
+      files.length.should.equal(expectedFileList.length);
 
-      fs.readFileSync(path.format(fileObj)).toString().should.equal('existnow');
+      fs.readFileSync(path.format(fileObj))
+        .toString()
+        .should.equal("existnow");
     });
   });
 
-  describe('when old files exist with contents', () => {
+  describe("when old files exist with contents", () => {
     const fileObj = generateTestFile();
     let s;
 
     before(done => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       fs.ensureFileSync(fileObj.path);
-      fs.writeFileSync(fileObj.path, 'This is exactly 30 bytes long\n');
+      fs.writeFileSync(fileObj.path, "This is exactly 30 bytes long\n");
       s = new RollingFileWriteStream(fileObj.path, { maxSize: 35 });
-      s.write('one\n', 'utf8'); //34
-      s.write('two\n', 'utf8'); //38 - file should be rotated next time
-      s.write('three\n', 'utf8', done); // this should be in a new file.
+      s.write("one\n", "utf8"); //34
+      s.write("two\n", "utf8"); //38 - file should be rotated next time
+      s.write("three\n", "utf8", done); // this should be in a new file.
     });
 
     after(() => {
@@ -718,29 +1084,89 @@ describe('RollingFileWriteStream', () => {
       fs.removeSync(fileObj.dir);
     });
 
-    it('should respect the existing file size', () => {
+    it("should respect the existing file size", () => {
       const files = fs.readdirSync(fileObj.dir);
-      const expectedFileList = [fileObj.base, fileObj.base + '.1'];
-      files.length.should.equal(expectedFileList.length);
+      const expectedFileList = [fileObj.base, fileObj.base + ".1"];
       files.should.containDeep(expectedFileList);
+      files.length.should.equal(expectedFileList.length);
 
-      fs.readFileSync(path.format(fileObj)).toString().should.equal('three\n');
-      fs.readFileSync(path.join(fileObj.dir, fileObj.base + '.1')).toString().should.equal('This is exactly 30 bytes long\none\ntwo\n');
-
+      fs.readFileSync(path.format(fileObj))
+        .toString()
+        .should.equal("three\n");
+      fs.readFileSync(path.join(fileObj.dir, fileObj.base + ".1"))
+        .toString()
+        .should.equal("This is exactly 30 bytes long\none\ntwo\n");
     });
   });
 
-  describe('when old files exist with contents and rolling by date', () => {
+  describe("when old files exist with indices", () => {
+    const fileObj = generateTestFile();
+    let s;
+
+    before(done => {
+      fs.ensureFileSync(fileObj.path);
+      fs.writeFileSync(
+        fileObj.path,
+        "This was the base file and it should be more than 30 bytes\n"
+      ); // base
+      fs.writeFileSync(fileObj.path + ".1", "This was the first old file\n"); // base.1
+      s = new RollingFileWriteStream(fileObj.path, {
+        maxSize: 30,
+        numToKeep: 5
+      });
+      s.write("This is exactly 30 bytes long\n", "utf8"); // base.1 -> base.2, base -> base.1
+      s.write("This is exactly 30 bytes long\n", "utf8"); // base.2 -> base.3, base.1 -> base.2, base -> base.1
+      s.write("three\n", "utf8", done); // base.3 -> base.4, base.2 -> base.3, base.1 -> base.2, base -> base.1
+    });
+
+    after(() => {
+      s.end();
+      fs.removeSync(fileObj.dir);
+    });
+
+    it("should rotate the old file indices", () => {
+      const files = fs.readdirSync(fileObj.dir);
+      const expectedFileList = [
+        fileObj.base,
+        fileObj.base + ".1",
+        fileObj.base + ".2",
+        fileObj.base + ".3",
+        fileObj.base + ".4"
+      ];
+      files.should.containDeep(expectedFileList);
+      files.length.should.equal(expectedFileList.length);
+
+      fs.readFileSync(path.format(fileObj))
+        .toString()
+        .should.equal("three\n");
+      fs.readFileSync(path.join(fileObj.dir, fileObj.base + ".1"))
+        .toString()
+        .should.equal("This is exactly 30 bytes long\n");
+      fs.readFileSync(path.join(fileObj.dir, fileObj.base + ".2"))
+        .toString()
+        .should.equal("This is exactly 30 bytes long\n");
+      fs.readFileSync(path.join(fileObj.dir, fileObj.base + ".3"))
+        .toString()
+        .should.equal(
+          "This was the base file and it should be more than 30 bytes\n"
+        );
+      fs.readFileSync(path.join(fileObj.dir, fileObj.base + ".4"))
+        .toString()
+        .should.equal("This was the first old file\n");
+    });
+  });
+
+  describe("when old files exist with contents and rolling by date", () => {
     const fileObj = generateTestFile();
     let s;
 
     before(done => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       fs.ensureFileSync(fileObj.path);
-      fs.writeFileSync(fileObj.path, 'This was created Sept 12, 2012.\n');
+      fs.writeFileSync(fileObj.path, "This was created Sept 12, 2012.\n");
       fakeNow = new Date(2012, 8, 13, 10, 53, 12);
-      s = new RollingFileWriteStream(fileObj.path, { pattern: 'yyyy-MM-dd' });
-      s.write('It is now Sept 13, 2012.\n', 'utf8', done); // this should be in a new file.
+      s = new RollingFileWriteStream(fileObj.path, { pattern: "yyyy-MM-dd" });
+      s.write("It is now Sept 13, 2012.\n", "utf8", done); // this should be in a new file.
     });
 
     after(() => {
@@ -748,28 +1174,31 @@ describe('RollingFileWriteStream', () => {
       fs.removeSync(fileObj.dir);
     });
 
-    it('should respect the existing file date', () => {
+    it("should respect the existing file date", () => {
       const files = fs.readdirSync(fileObj.dir);
-      const expectedFileList = [fileObj.base, fileObj.base + '.2012-09-12'];
-      files.length.should.equal(expectedFileList.length);
+      const expectedFileList = [fileObj.base, fileObj.base + ".2012-09-12"];
       files.should.containDeep(expectedFileList);
+      files.length.should.equal(expectedFileList.length);
 
-      fs.readFileSync(path.format(fileObj)).toString().should.equal('It is now Sept 13, 2012.\n');
-      fs.readFileSync(path.join(fileObj.dir, fileObj.base + '.2012-09-12')).toString().should.equal('This was created Sept 12, 2012.\n');
-
+      fs.readFileSync(path.format(fileObj))
+        .toString()
+        .should.equal("It is now Sept 13, 2012.\n");
+      fs.readFileSync(path.join(fileObj.dir, fileObj.base + ".2012-09-12"))
+        .toString()
+        .should.equal("This was created Sept 12, 2012.\n");
     });
   });
 
-  describe('when old files exist with contents and stream created with overwrite flag', () => {
+  describe("when old files exist with contents and stream created with overwrite flag", () => {
     const fileObj = generateTestFile();
     let s;
 
     before(done => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       fs.ensureFileSync(fileObj.path);
-      fs.writeFileSync(fileObj.path, 'This is exactly 30 bytes long\n');
-      s = new RollingFileWriteStream(fileObj.path, { maxSize: 35, flags: 'w' });
-      s.write('there should only be this\n', 'utf8', done);
+      fs.writeFileSync(fileObj.path, "This is exactly 30 bytes long\n");
+      s = new RollingFileWriteStream(fileObj.path, { maxSize: 35, flags: "w" });
+      s.write("there should only be this\n", "utf8", done);
     });
 
     after(() => {
@@ -777,19 +1206,21 @@ describe('RollingFileWriteStream', () => {
       fs.removeSync(fileObj.dir);
     });
 
-    it('should ignore the existing file size', () => {
+    it("should ignore the existing file size", () => {
       const files = fs.readdirSync(fileObj.dir);
       const expectedFileList = [fileObj.base];
-      files.length.should.equal(expectedFileList.length);
       files.should.containDeep(expectedFileList);
+      files.length.should.equal(expectedFileList.length);
 
       s.state.currentSize.should.equal(26);
 
-      fs.readFileSync(path.format(fileObj)).toString().should.equal('there should only be this\n');
+      fs.readFileSync(path.format(fileObj))
+        .toString()
+        .should.equal("there should only be this\n");
     });
   });
 
-  describe('when dir does not exist', () => {
+  describe("when dir does not exist", () => {
     const fileObj = generateTestFile();
     let s;
 
@@ -797,7 +1228,7 @@ describe('RollingFileWriteStream', () => {
       fs.removeSync(fileObj.dir);
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path);
-      s.write('test', 'utf8', done);
+      s.write("test", "utf8", done);
     });
 
     after(() => {
@@ -805,72 +1236,75 @@ describe('RollingFileWriteStream', () => {
       fs.removeSync(fileObj.dir);
     });
 
-    it('should create the dir', () => {
+    it("should create the dir", () => {
       const files = fs.readdirSync(fileObj.dir);
       const expectedFileList = [fileObj.base];
-      files.length.should.equal(expectedFileList.length);
       files.should.containDeep(expectedFileList);
+      files.length.should.equal(expectedFileList.length);
 
-      fs.readFileSync(path.format(fileObj)).toString().should.equal('test');
+      fs.readFileSync(path.format(fileObj))
+        .toString()
+        .should.equal("test");
     });
   });
 
-  describe('when given just a base filename with no dir', () => {
+  describe("when given just a base filename with no dir", () => {
     let s;
     before(done => {
-      s = new RollingFileWriteStream('test.log');
-      s.write('this should not cause any problems', 'utf8', done);
+      s = new RollingFileWriteStream("test.log");
+      s.write("this should not cause any problems", "utf8", done);
     });
 
     after(() => {
       s.end();
-      fs.removeSync('test.log');
+      fs.removeSync("test.log");
     });
 
-    it('should use process.cwd() as the dir', () => {
+    it("should use process.cwd() as the dir", () => {
       const files = fs.readdirSync(process.cwd());
-      files.should.containDeep(['test.log']);
+      files.should.containDeep(["test.log"]);
 
-      fs.readFileSync(
-        path.join(process.cwd(), 'test.log')
-      ).toString().should.equal('this should not cause any problems');
+      fs.readFileSync(path.join(process.cwd(), "test.log"))
+        .toString()
+        .should.equal("this should not cause any problems");
     });
   });
 
-  describe('with no callback to write', () => {
+  describe("with no callback to write", () => {
     let s;
     before(done => {
-      s = new RollingFileWriteStream('no-callback.log');
-      s.write('this is all very nice', 'utf8', done);
+      s = new RollingFileWriteStream("no-callback.log");
+      s.write("this is all very nice", "utf8", done);
     });
 
     after(done => {
-      fs.remove('no-callback.log', done);
+      fs.remove("no-callback.log", done);
     });
 
-    it('should not complain', done => {
-        s.write('I am not bothered if this succeeds or not');
-        s.end(done);
+    it("should not complain", done => {
+      s.write("I am not bothered if this succeeds or not");
+      s.end(done);
     });
   });
 
-  describe('events', () => {
+  describe("events", () => {
     let s;
     before(done => {
-      s = new RollingFileWriteStream('test-events.log');
-      s.write('this should not cause any problems', 'utf8', done);
+      s = new RollingFileWriteStream("test-events.log");
+      s.write("this should not cause any problems", "utf8", done);
     });
 
     after(() => {
       s.end();
-      fs.removeSync('test-events.log');
+      fs.removeSync("test-events.log");
     });
 
-    it('should emit the error event of the underlying stream', (done) => {
-      s.on('error', (e) => { e.message.should.equal('oh no'); done(); });
-      s.currentFileStream.emit('error', new Error('oh no'));
+    it("should emit the error event of the underlying stream", done => {
+      s.on("error", e => {
+        e.message.should.equal("oh no");
+        done();
+      });
+      s.currentFileStream.emit("error", new Error("oh no"));
     });
-
   });
-
 });


### PR DESCRIPTION
This PR fixes #42 - when rolling the old code would only keep track of files it had created during the current run, ignoring old files from previous runs.

Urgh. Installed the "prettier" plugin for atom and it has decided to convert all single quote strings to double quotes, so there's a lot of noise in the diffs below.