### PR TITLE
refactor: replace lodash helpers with native alternatives

### DIFF
--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -1,5 +1,4 @@
 const debug = require("debug")("streamroller:RollingFileWriteStream");
-const _ = require("lodash");
 const async = require("async");
 const fs = require("fs-extra");
 const zlib = require("zlib");
@@ -146,7 +145,7 @@ class RollingFileWriteStream extends Writable {
       keepFileExt: false,
       alwaysIncludePattern: false
     };
-    const options = _.defaults({}, rawOptions, defaultOptions);
+    const options = Object.assign({}, defaultOptions, rawOptions);
     if (options.maxSize <= 0) {
       throw new Error(`options.maxSize (${options.maxSize}) should be > 0`);
     }
@@ -198,11 +197,13 @@ class RollingFileWriteStream extends Writable {
   _getExistingFiles(cb) {
     fs.readdir(this.fileObject.dir, (e, files) => {
       debug(`_getExistingFiles: files=${files}`);
-      const existingFileDetails = _.chain(files)
+      const existingFileDetails = (files || [])
         .map(n => this.fileNameParser(n))
-        .compact()
-        .sortBy(n => (n.timestamp ? n.timestamp : newNow().getTime()) - n.index)
-        .value();
+        .filter(n => n !== undefined && n !== null);
+
+      const getKey = n => (n.timestamp ? n.timestamp : newNow().getTime()) - n.index
+      existingFileDetails.sort((a, b) => getKey(a) - getKey(b))
+
       cb(null, existingFileDetails);
     });
   }
@@ -274,7 +275,11 @@ class RollingFileWriteStream extends Writable {
       date: this.state.currentDate,
       index: 0
     });
-    const ops = _.pick(this.options, ["flags", "encoding", "mode"]);
+    const ops = {
+      flags: this.options.flags,
+      encoding: this.options.encoding,
+      mode: this.options.mode,
+    };
     this.currentFileStream = fs.createWriteStream(filePath, ops);
     this.currentFileStream.on("error", e => {
       this.emit("error", e);
@@ -291,8 +296,7 @@ class RollingFileWriteStream extends Writable {
         this.options.numToKeep > 0 &&
         existingFileDetails.length > this.options.numToKeep
       ) {
-        const fileNamesToRemove = _.slice(
-          existingFileDetails.map(f => f.filename),
+        const fileNamesToRemove = existingFileDetails.map(f => f.filename).slice(
           0,
           existingFileDetails.length - this.options.numToKeep - 1
         );
@@ -306,7 +310,7 @@ class RollingFileWriteStream extends Writable {
   _deleteFiles(fileNames, done) {
     debug(`files to delete: ${fileNames}`);
     async.each(
-      _.map(fileNames, f => path.format({ dir: this.fileObject.dir, base: f })),
+      fileNames.map(f => path.format({ dir: this.fileObject.dir, base: f })),
       fs.unlink,
       done
     );

--- a/lib/fileNameParser.js
+++ b/lib/fileNameParser.js
@@ -1,7 +1,6 @@
 const debug = require("debug")("streamroller:fileNameParser");
 const FILENAME_SEP = ".";
 const ZIP_EXT = ".gz";
-const _ = require("lodash");
 const format = require("date-format");
 
 module.exports = ({ file, keepFileExt, pattern }) => {
@@ -9,7 +8,7 @@ module.exports = ({ file, keepFileExt, pattern }) => {
   // They return the filename with any matching parts removed.
   // The "zip" function, for instance, removes the ".gz" part of the filename (if present)
   const zip = (f, p) => {
-    if (_.endsWith(f, ZIP_EXT)) {
+    if (f.endsWith(ZIP_EXT)) {
       debug("it is gzipped");
       p.isCompressed = true;
       return f.slice(0, -1 * ZIP_EXT.length);
@@ -18,7 +17,7 @@ module.exports = ({ file, keepFileExt, pattern }) => {
   };
 
   const extAtEnd = f => {
-    if (_.startsWith(f, file.name) && _.endsWith(f, file.ext)) {
+    if (f.startsWith(file.name) && f.endsWith(file.ext)) {
       debug("it starts and ends with the right things");
       return f.slice(file.name.length + 1, -1 * file.ext.length);
     }
@@ -26,7 +25,7 @@ module.exports = ({ file, keepFileExt, pattern }) => {
   };
 
   const extInMiddle = f => {
-    if (_.startsWith(f, file.base)) {
+    if (f.startsWith(file.base)) {
       debug("it starts with the right things");
       return f.slice(file.base.length + 1);
     }
@@ -34,7 +33,7 @@ module.exports = ({ file, keepFileExt, pattern }) => {
   };
 
   const dateAndIndex = (f, p) => {
-    const items = _.split(f, FILENAME_SEP);
+    const items = f.split(FILENAME_SEP);
     let indexStr = items[items.length - 1];
     debug("items: ", items, ", indexStr: ", indexStr);
     let dateStr = f;

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "async": "^2.6.3",
     "date-format": "^2.1.0",
     "debug": "^4.1.1",
-    "fs-extra": "^8.1.0",
-    "lodash": "^4.17.14"
+    "fs-extra": "^8.1.0"
   },
   "engines": {
     "node": ">=8.0"

--- a/test/RollingFileWriteStream-test.js
+++ b/test/RollingFileWriteStream-test.js
@@ -1,6 +1,5 @@
 require("should");
 
-const _ = require("lodash");
 const path = require("path");
 const zlib = require("zlib");
 const async = require("async");
@@ -162,7 +161,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("353637");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-12.1"
           })
         )
@@ -171,7 +170,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("01234");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-13.1"
           })
         )
@@ -180,7 +179,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("56789");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-14.2"
           })
         )
@@ -189,7 +188,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("101112");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-14.1"
           })
         )
@@ -198,7 +197,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("1314");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-15.2"
           })
         )
@@ -207,7 +206,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("151617");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-15.1"
           })
         )
@@ -216,7 +215,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("1819");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-16.2"
           })
         )
@@ -225,7 +224,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("202122");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-16.1"
           })
         )
@@ -234,7 +233,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("2324");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-17.2"
           })
         )
@@ -243,7 +242,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("252627");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-17.1"
           })
         )
@@ -252,7 +251,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("2829");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-18.2"
           })
         )
@@ -261,7 +260,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("303132");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-18.1"
           })
         )
@@ -295,7 +294,7 @@ describe("RollingFileWriteStream", () => {
       files.length.should.equal(expectedFileList.length);
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base
           })
         )
@@ -351,7 +350,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("3637");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-12.2"
           })
         )
@@ -360,7 +359,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("01234");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-12.1"
           })
         )
@@ -369,7 +368,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("56789");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-13.4"
           })
         )
@@ -378,7 +377,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("101112");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-13.3"
           })
         )
@@ -387,7 +386,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("131415");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-13.2"
           })
         )
@@ -396,7 +395,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("161718");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-13.1"
           })
         )
@@ -405,7 +404,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("19");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-14.4"
           })
         )
@@ -414,7 +413,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("202122");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-14.3"
           })
         )
@@ -423,7 +422,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("232425");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-14.2"
           })
         )
@@ -432,7 +431,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("262728");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-14.1"
           })
         )
@@ -441,7 +440,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("29");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-15.2"
           })
         )
@@ -450,7 +449,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("303132");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-15.1"
           })
         )
@@ -497,7 +496,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("37");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".1"
           })
         )
@@ -506,7 +505,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("343536");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2"
           })
         )
@@ -515,7 +514,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("313233");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".3"
           })
         )
@@ -563,7 +562,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("3637");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-15.1"
           })
         )
@@ -572,7 +571,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("333435");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-15.2"
           })
         )
@@ -581,7 +580,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("303132");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-14.1"
           })
         )
@@ -624,7 +623,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("567");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".12-09-2012.1"
           })
         )
@@ -671,7 +670,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("567");
       const content = fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.base + ".2012-09-12.1.gz"
           })
         )
@@ -769,7 +768,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("567");
       const content = fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.name + ".2012-09-12.1.log.gz"
           })
         )
@@ -816,7 +815,7 @@ describe("RollingFileWriteStream", () => {
       files.length.should.equal(expectedFileList.length);
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.name + ".2012-09-13.log"
           })
         )
@@ -825,7 +824,7 @@ describe("RollingFileWriteStream", () => {
         .should.equal("567");
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.name + ".2012-09-12.1.log"
           })
         )
@@ -882,7 +881,7 @@ describe("RollingFileWriteStream", () => {
       files.length.should.equal(expectedFileList.length);
       fs.readFileSync(
         path.format(
-          _.assign({}, fileObj, {
+          Object.assign({}, fileObj, {
             base: fileObj.name + ".2012-09-19.log"
           })
         )
@@ -893,7 +892,7 @@ describe("RollingFileWriteStream", () => {
         .gunzipSync(
           fs.readFileSync(
             path.format(
-              _.assign({}, fileObj, {
+              Object.assign({}, fileObj, {
                 base: fileObj.name + ".2012-09-18.1.log.gz"
               })
             )
@@ -905,7 +904,7 @@ describe("RollingFileWriteStream", () => {
         .gunzipSync(
           fs.readFileSync(
             path.format(
-              _.assign({}, fileObj, {
+              Object.assign({}, fileObj, {
                 base: fileObj.name + ".2012-09-18.2.log.gz"
               })
             )
@@ -917,7 +916,7 @@ describe("RollingFileWriteStream", () => {
         .gunzipSync(
           fs.readFileSync(
             path.format(
-              _.assign({}, fileObj, {
+              Object.assign({}, fileObj, {
                 base: fileObj.name + ".2012-09-17.1.log.gz"
               })
             )
@@ -929,7 +928,7 @@ describe("RollingFileWriteStream", () => {
         .gunzipSync(
           fs.readFileSync(
             path.format(
-              _.assign({}, fileObj, {
+              Object.assign({}, fileObj, {
                 base: fileObj.name + ".2012-09-17.2.log.gz"
               })
             )
@@ -941,7 +940,7 @@ describe("RollingFileWriteStream", () => {
         .gunzipSync(
           fs.readFileSync(
             path.format(
-              _.assign({}, fileObj, {
+              Object.assign({}, fileObj, {
                 base: fileObj.name + ".2012-09-16.1.log.gz"
               })
             )
@@ -953,7 +952,7 @@ describe("RollingFileWriteStream", () => {
         .gunzipSync(
           fs.readFileSync(
             path.format(
-              _.assign({}, fileObj, {
+              Object.assign({}, fileObj, {
                 base: fileObj.name + ".2012-09-16.2.log.gz"
               })
             )
@@ -965,7 +964,7 @@ describe("RollingFileWriteStream", () => {
         .gunzipSync(
           fs.readFileSync(
             path.format(
-              _.assign({}, fileObj, {
+              Object.assign({}, fileObj, {
                 base: fileObj.name + ".2012-09-15.1.log.gz"
               })
             )
@@ -977,7 +976,7 @@ describe("RollingFileWriteStream", () => {
         .gunzipSync(
           fs.readFileSync(
             path.format(
-              _.assign({}, fileObj, {
+              Object.assign({}, fileObj, {
                 base: fileObj.name + ".2012-09-15.2.log.gz"
               })
             )
@@ -989,7 +988,7 @@ describe("RollingFileWriteStream", () => {
         .gunzipSync(
           fs.readFileSync(
             path.format(
-              _.assign({}, fileObj, {
+              Object.assign({}, fileObj, {
                 base: fileObj.name + ".2012-09-14.1.log.gz"
               })
             )
@@ -1001,7 +1000,7 @@ describe("RollingFileWriteStream", () => {
         .gunzipSync(
           fs.readFileSync(
             path.format(
-              _.assign({}, fileObj, {
+              Object.assign({}, fileObj, {
                 base: fileObj.name + ".2012-09-14.2.log.gz"
               })
             )
@@ -1013,7 +1012,7 @@ describe("RollingFileWriteStream", () => {
         .gunzipSync(
           fs.readFileSync(
             path.format(
-              _.assign({}, fileObj, {
+              Object.assign({}, fileObj, {
                 base: fileObj.name + ".2012-09-13.1.log.gz"
               })
             )
@@ -1025,7 +1024,7 @@ describe("RollingFileWriteStream", () => {
         .gunzipSync(
           fs.readFileSync(
             path.format(
-              _.assign({}, fileObj, {
+              Object.assign({}, fileObj, {
                 base: fileObj.name + ".2012-09-12.1.log.gz"
               })
             )


### PR DESCRIPTION
To reduce amount of non critical dependencies given that readability and expressiveness is comparable.

I just noticed that this PR conflicts a bit with https://github.com/log4js-node/streamroller/tree/simplify branch. I can rebase it once `simplify` is merged.

It also looks like it will be rather easy to eliminate `async` from production dependencies.

What do you think about these changes?