### PR TITLE
Simplifying some of the more complicated functions

### DIFF
--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -198,23 +198,12 @@ class RollingFileWriteStream extends Writable {
   _getExistingFiles(cb) {
     fs.readdir(this.fileObject.dir, (e, files) => {
       debug(`_getExistingFiles: files=${files}`);
-      const existingFileDetails = _.compact(
-        _.map(files, n => {
-          const parseResult = this.fileNameParser(n);
-          debug(`_getExistingFiles: parsed ${n} as `, parseResult);
-          if (!parseResult) {
-            return;
-          }
-          return _.assign({ fileName: n }, parseResult);
-        })
-      );
-      cb(
-        null,
-        _.sortBy(
-          existingFileDetails,
-          n => (n.timestamp ? n.timestamp : newNow().getTime()) - n.index
-        )
-      );
+      const existingFileDetails = _.chain(files)
+        .map(n => this.fileNameParser(n))
+        .compact()
+        .sortBy(n => (n.timestamp ? n.timestamp : newNow().getTime()) - n.index)
+        .value();
+      cb(null, existingFileDetails);
     });
   }
 
@@ -303,7 +292,7 @@ class RollingFileWriteStream extends Writable {
         existingFileDetails.length > this.options.numToKeep
       ) {
         const fileNamesToRemove = _.slice(
-          existingFileDetails.map(f => f.fileName),
+          existingFileDetails.map(f => f.filename),
           0,
           existingFileDetails.length - this.options.numToKeep - 1
         );

--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -106,19 +106,17 @@ class RollingFileWriteStream extends Writable {
       this.state.currentDate = format(this.options.pattern, newNow());
     }
 
-    this.justTheFile = this.fileFormatter({
+    this.filename = this.fileFormatter({
       index: 0,
       date: this.state.currentDate
     });
-    this.filename = path.join(this.fileObject.dir, this.justTheFile);
-
     if (this.options.flags === "a") {
       this._setExistingSizeAndDate();
     }
 
     debug(
       `create new file with no hot file. name=${
-        this.justTheFile
+        this.filename
       }, state=${JSON.stringify(this.state)}`
     );
     this._renewWriteStream();
@@ -159,24 +157,23 @@ class RollingFileWriteStream extends Writable {
     return options;
   }
 
-  _shouldRoll(callback) {
-    if (
+  _dateChanged() {
+    return (
       this.state.currentDate &&
       this.state.currentDate !== format(this.options.pattern, newNow())
-    ) {
+    );
+  }
+
+  _tooBig() {
+    return this.state.currentSize >= this.options.maxSize;
+  }
+
+  _shouldRoll(callback) {
+    if (this._dateChanged() || this._tooBig()) {
       debug(
-        `_shouldRoll: rolling by date because ${
-          this.state.currentDate
-        } !== ${format(this.options.pattern, newNow())}`
+        `rolling because dateChanged? ${this._dateChanged()} or tooBig? ${this._tooBig()}`
       );
-      this._roll({ isNextPeriod: true }, callback);
-      return;
-    }
-    if (this.state.currentSize >= this.options.maxSize) {
-      debug(
-        `_shouldRoll: rolling by size because ${this.state.currentSize} >= ${this.options.maxSize}`
-      );
-      this._roll({ isNextPeriod: false }, callback);
+      this._roll(callback);
       return;
     }
     callback();
@@ -221,9 +218,8 @@ class RollingFileWriteStream extends Writable {
     });
   }
 
-  _moveOldFiles(isNextPeriod, cb) {
+  _moveOldFiles(cb) {
     const currentFilePath = this.currentFileStream.path;
-    debug(`numToKeep = ${this.options.numToKeep}`);
 
     this._getExistingFiles((e, files) => {
       const filesToMove = [];
@@ -235,19 +231,13 @@ class RollingFileWriteStream extends Writable {
         const sourceFilePath =
           i === 0
             ? currentFilePath
-            : path.format({
-                dir: this.fileObject.dir,
-                base: this.fileFormatter({
-                  date: this.state.currentDate,
-                  index: i
-                })
+            : this.fileFormatter({
+                date: this.state.currentDate,
+                index: i
               });
-        const targetFilePath = path.format({
-          dir: this.fileObject.dir,
-          base: this.fileFormatter({
-            date: this.state.currentDate,
-            index: i + 1
-          })
+        const targetFilePath = this.fileFormatter({
+          date: this.state.currentDate,
+          index: i + 1
         });
         filesToMove.push({ sourceFilePath, targetFilePath });
       }
@@ -268,20 +258,11 @@ class RollingFileWriteStream extends Writable {
           );
         },
         () => {
-          if (isNextPeriod) {
-            this.state.currentSize = 0;
-            this.state.currentDate = format(this.options.pattern, newNow());
-            debug(
-              `rolling for next period. state=${JSON.stringify(this.state)}`
-            );
-          } else {
-            this.state.currentSize = 0;
-            debug(
-              `rolling during the same period. state=${JSON.stringify(
-                this.state
-              )}`
-            );
-          }
+          this.state.currentSize = 0;
+          this.state.currentDate = this.state.currentDate
+            ? format(this.options.pattern, newNow())
+            : null;
+          debug(`finished rolling files. state=${JSON.stringify(this.state)}`);
           this._renewWriteStream();
           // wait for the file to be open before cleaning up old ones,
           // otherwise the daysToKeep calculations can be off
@@ -291,23 +272,18 @@ class RollingFileWriteStream extends Writable {
     });
   }
 
-  _roll({ isNextPeriod }, cb) {
-    debug(`rolling, isNextPeriod ? ${isNextPeriod}`);
+  _roll(cb) {
     debug(`_roll: closing the current stream`);
     this.currentFileStream.end("", this.options.encoding, () => {
-      this._moveOldFiles(isNextPeriod, cb);
+      this._moveOldFiles(cb);
     });
   }
 
   _renewWriteStream() {
     fs.ensureDirSync(this.fileObject.dir);
-    this.justTheFile = this.fileFormatter({
+    const filePath = this.fileFormatter({
       date: this.state.currentDate,
       index: 0
-    });
-    const filePath = path.format({
-      dir: this.fileObject.dir,
-      base: this.justTheFile
     });
     const ops = _.pick(this.options, ["flags", "encoding", "mode"]);
     this.currentFileStream = fs.createWriteStream(filePath, ops);

--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -7,9 +7,8 @@ const path = require("path");
 const newNow = require("./now");
 const format = require("date-format");
 const { Writable } = require("stream");
-
-const FILENAME_SEP = ".";
-const ZIP_EXT = ".gz";
+const fileNameFormatter = require("./fileNameFormatter");
+const fileNameParser = require("./fileNameParser");
 
 const moveAndMaybeCompressFile = (
   sourceFilePath,
@@ -59,7 +58,7 @@ const moveAndMaybeCompressFile = (
 
 /**
  * RollingFileWriteStream is mainly used when writing to a file rolling by date or size.
- * RollingFileWriteStream inhebites from stream.Writable
+ * RollingFileWriteStream inherits from stream.Writable
  */
 class RollingFileWriteStream extends Writable {
   /**
@@ -85,8 +84,20 @@ class RollingFileWriteStream extends Writable {
     if (this.fileObject.dir === "") {
       this.fileObject = path.parse(path.join(process.cwd(), filePath));
     }
-    this.justTheFile = this._formatFileName({ isHotFile: true });
-    this.filename = path.join(this.fileObject.dir, this.justTheFile);
+    this.fileFormatter = fileNameFormatter({
+      file: this.fileObject,
+      alwaysIncludeDate: this.options.alwaysIncludePattern,
+      needsIndex: this.options.maxSize < Number.MAX_SAFE_INTEGER,
+      compress: this.options.compress,
+      keepFileExt: this.options.keepFileExt
+    });
+
+    this.fileNameParser = fileNameParser({
+      file: this.fileObject,
+      keepFileExt: this.options.keepFileExt,
+      pattern: this.options.pattern
+    });
+
     this.state = {
       currentSize: 0
     };
@@ -94,6 +105,12 @@ class RollingFileWriteStream extends Writable {
     if (this.options.pattern) {
       this.state.currentDate = format(this.options.pattern, newNow());
     }
+
+    this.justTheFile = this.fileFormatter({
+      index: 0,
+      date: this.state.currentDate
+    });
+    this.filename = path.join(this.fileObject.dir, this.justTheFile);
 
     if (this.options.flags === "a") {
       this._setExistingSizeAndDate();
@@ -186,7 +203,7 @@ class RollingFileWriteStream extends Writable {
       debug(`_getExistingFiles: files=${files}`);
       const existingFileDetails = _.compact(
         _.map(files, n => {
-          const parseResult = this._parseFileName(n);
+          const parseResult = this.fileNameParser(n);
           debug(`_getExistingFiles: parsed ${n} as `, parseResult);
           if (!parseResult) {
             return;
@@ -198,150 +215,15 @@ class RollingFileWriteStream extends Writable {
         null,
         _.sortBy(
           existingFileDetails,
-          n =>
-            (n.date
-              ? format.parse(this.options.pattern, n.date).valueOf()
-              : newNow().valueOf()) - n.index
+          n => (n.timestamp ? n.timestamp : newNow().getTime()) - n.index
         )
       );
     });
   }
 
-  // need file name instead of file abs path.
-  _parseFileName(fileName) {
-    let isCompressed = false;
-    if (fileName.endsWith(ZIP_EXT)) {
-      fileName = fileName.slice(0, -1 * ZIP_EXT.length);
-      isCompressed = true;
-    }
-    let metaStr;
-    if (this.options.keepFileExt) {
-      const prefix = this.fileObject.name + FILENAME_SEP;
-      const suffix = this.fileObject.ext;
-      if (!fileName.startsWith(prefix) || !fileName.endsWith(suffix)) {
-        return;
-      }
-      metaStr = fileName.slice(prefix.length, -1 * suffix.length);
-      debug(
-        `metaStr=${metaStr}, fileName=${fileName}, prefix=${prefix}, suffix=${suffix}`
-      );
-    } else {
-      const prefix = this.fileObject.base;
-      if (!fileName.startsWith(prefix)) {
-        return;
-      }
-      metaStr = fileName.slice(prefix.length + 1);
-      debug(`metaStr=${metaStr}, fileName=${fileName}, prefix=${prefix}`);
-    }
-    if (!metaStr) {
-      return {
-        index: 0,
-        isCompressed
-      };
-    }
-    if (this.options.pattern) {
-      const items = _.split(metaStr, FILENAME_SEP);
-      const indexStr = items[items.length - 1];
-      debug("items: ", items, ", indexStr: ", indexStr);
-      if (indexStr !== undefined && indexStr.match(/^\d+$/)) {
-        const dateStr = metaStr.slice(0, -1 * (indexStr.length + 1));
-        debug(`dateStr is ${dateStr}`);
-        if (dateStr) {
-          return {
-            index: parseInt(indexStr, 10),
-            date: dateStr,
-            isCompressed
-          };
-        }
-      }
-      debug(`metaStr is ${metaStr}`);
-      return {
-        index: 0,
-        date: metaStr,
-        isCompressed
-      };
-    } else {
-      if (metaStr.match(/^\d+$/)) {
-        return {
-          index: parseInt(metaStr, 10),
-          isCompressed
-        };
-      }
-    }
-    return;
-  }
-
-  _formatFileName({ date, index, isHotFile }) {
-    debug(
-      `_formatFileName: date=${date}, index=${index}, isHotFile=${isHotFile}`
-    );
-    const dateStr =
-      date ||
-      _.get(this, "state.currentDate") ||
-      format(this.options.pattern, newNow());
-    const indexOpt = index || _.get(this, "state.currentIndex");
-    const oriFileName = this.fileObject.base;
-    if (isHotFile) {
-      debug(
-        `_formatFileName: includePattern? ${this.options.alwaysIncludePattern}, pattern: ${this.options.pattern}`
-      );
-      if (this.options.alwaysIncludePattern && this.options.pattern) {
-        debug(
-          `_formatFileName: is hot file, and include pattern, so: ${oriFileName +
-            FILENAME_SEP +
-            dateStr}`
-        );
-        return this.options.keepFileExt
-          ? this.fileObject.name + FILENAME_SEP + dateStr + this.fileObject.ext
-          : oriFileName + FILENAME_SEP + dateStr;
-      }
-      debug(`_formatFileName: is hot file so, filename: ${oriFileName}`);
-      return oriFileName;
-    }
-    let fileNameExtraItems = [];
-    if (this.options.pattern) {
-      fileNameExtraItems.push(dateStr);
-    }
-    if (indexOpt && this.options.maxSize < Number.MAX_SAFE_INTEGER) {
-      fileNameExtraItems.push(indexOpt);
-    }
-    let fileName;
-    if (this.options.keepFileExt) {
-      const baseFileName =
-        this.fileObject.name +
-        FILENAME_SEP +
-        fileNameExtraItems.join(FILENAME_SEP);
-      fileName = baseFileName + this.fileObject.ext;
-    } else {
-      fileName =
-        oriFileName + FILENAME_SEP + fileNameExtraItems.join(FILENAME_SEP);
-    }
-    if (this.options.compress) {
-      fileName += ZIP_EXT;
-    }
-    debug(`_formatFileName: ${fileName}`);
-    return fileName;
-  }
-
   _moveOldFiles(isNextPeriod, cb) {
     const currentFilePath = this.currentFileStream.path;
     debug(`numToKeep = ${this.options.numToKeep}`);
-    const finishedRolling = () => {
-      if (isNextPeriod) {
-        this.state.currentSize = 0;
-        this.state.currentDate = format(this.options.pattern, newNow());
-        debug(`rolling for next period. state=${JSON.stringify(this.state)}`);
-      } else {
-        this.state.currentSize = 0;
-        debug(
-          `rolling during the same period. state=${JSON.stringify(this.state)}`
-        );
-      }
-      this._renewWriteStream();
-      // wait for the file to be open before cleaning up old ones,
-      // otherwise the daysToKeep calculations can be off
-      this.currentFileStream.write("", "utf8", () => this._clean(cb));
-    };
 
     this._getExistingFiles((e, files) => {
       const filesToMove = [];
@@ -355,14 +237,14 @@ class RollingFileWriteStream extends Writable {
             ? currentFilePath
             : path.format({
                 dir: this.fileObject.dir,
-                base: this._formatFileName({
+                base: this.fileFormatter({
                   date: this.state.currentDate,
                   index: i
                 })
               });
         const targetFilePath = path.format({
           dir: this.fileObject.dir,
-          base: this._formatFileName({
+          base: this.fileFormatter({
             date: this.state.currentDate,
             index: i + 1
           })
@@ -385,7 +267,26 @@ class RollingFileWriteStream extends Writable {
             cb1
           );
         },
-        finishedRolling
+        () => {
+          if (isNextPeriod) {
+            this.state.currentSize = 0;
+            this.state.currentDate = format(this.options.pattern, newNow());
+            debug(
+              `rolling for next period. state=${JSON.stringify(this.state)}`
+            );
+          } else {
+            this.state.currentSize = 0;
+            debug(
+              `rolling during the same period. state=${JSON.stringify(
+                this.state
+              )}`
+            );
+          }
+          this._renewWriteStream();
+          // wait for the file to be open before cleaning up old ones,
+          // otherwise the daysToKeep calculations can be off
+          this.currentFileStream.write("", "utf8", () => this._clean(cb));
+        }
       );
     });
   }
@@ -400,10 +301,9 @@ class RollingFileWriteStream extends Writable {
 
   _renewWriteStream() {
     fs.ensureDirSync(this.fileObject.dir);
-    this.justTheFile = this._formatFileName({
+    this.justTheFile = this.fileFormatter({
       date: this.state.currentDate,
-      index: 0,
-      isHotFile: true
+      index: 0
     });
     const filePath = path.format({
       dir: this.fileObject.dir,

--- a/lib/fileNameFormatter.js
+++ b/lib/fileNameFormatter.js
@@ -1,4 +1,5 @@
 const debug = require("debug")("streamroller:fileNameFormatter");
+const path = require("path");
 const FILENAME_SEP = ".";
 const ZIP_EXT = ".gz";
 
@@ -17,10 +18,11 @@ module.exports = ({
     return (i > 0 || alwaysIncludeDate) && d ? f + FILENAME_SEP + d : f;
   };
   const gzip = (f, i) => (i && compress ? f + ZIP_EXT : f);
+  const dir = f => path.join(file.dir, f);
 
   const parts = keepFileExt
-    ? [name, date, index, ext, gzip]
-    : [name, ext, date, index, gzip];
+    ? [name, date, index, ext, gzip, dir]
+    : [name, ext, date, index, gzip, dir];
 
   return ({ date, index }) => {
     debug(`_formatFileName: date=${date}, index=${index}`);

--- a/lib/fileNameFormatter.js
+++ b/lib/fileNameFormatter.js
@@ -11,12 +11,16 @@ module.exports = ({
   compress
 }) => {
   const dirAndName = path.join(file.dir, file.name);
+
   const ext = f => f + file.ext;
+
   const index = (f, i, d) =>
     (needsIndex || !d) && i ? f + FILENAME_SEP + i : f;
+
   const date = (f, i, d) => {
     return (i > 0 || alwaysIncludeDate) && d ? f + FILENAME_SEP + d : f;
   };
+
   const gzip = (f, i) => (i && compress ? f + ZIP_EXT : f);
 
   const parts = keepFileExt

--- a/lib/fileNameFormatter.js
+++ b/lib/fileNameFormatter.js
@@ -10,7 +10,7 @@ module.exports = ({
   alwaysIncludeDate,
   compress
 }) => {
-  const name = f => f + file.name;
+  const dirAndName = path.join(file.dir, file.name);
   const ext = f => f + file.ext;
   const index = (f, i, d) =>
     (needsIndex || !d) && i ? f + FILENAME_SEP + i : f;
@@ -18,14 +18,16 @@ module.exports = ({
     return (i > 0 || alwaysIncludeDate) && d ? f + FILENAME_SEP + d : f;
   };
   const gzip = (f, i) => (i && compress ? f + ZIP_EXT : f);
-  const dir = f => path.join(file.dir, f);
 
   const parts = keepFileExt
-    ? [name, date, index, ext, gzip, dir]
-    : [name, ext, date, index, gzip, dir];
+    ? [date, index, ext, gzip]
+    : [ext, date, index, gzip];
 
   return ({ date, index }) => {
     debug(`_formatFileName: date=${date}, index=${index}`);
-    return parts.reduce((filename, part) => part(filename, index, date), "");
+    return parts.reduce(
+      (filename, part) => part(filename, index, date),
+      dirAndName
+    );
   };
 };

--- a/lib/fileNameFormatter.js
+++ b/lib/fileNameFormatter.js
@@ -1,0 +1,29 @@
+const debug = require("debug")("streamroller:fileNameFormatter");
+const FILENAME_SEP = ".";
+const ZIP_EXT = ".gz";
+
+module.exports = ({
+  file,
+  keepFileExt,
+  needsIndex,
+  alwaysIncludeDate,
+  compress
+}) => {
+  const name = f => f + file.name;
+  const ext = f => f + file.ext;
+  const index = (f, i, d) =>
+    (needsIndex || !d) && i ? f + FILENAME_SEP + i : f;
+  const date = (f, i, d) => {
+    return (i > 0 || alwaysIncludeDate) && d ? f + FILENAME_SEP + d : f;
+  };
+  const gzip = (f, i) => (i && compress ? f + ZIP_EXT : f);
+
+  const parts = keepFileExt
+    ? [name, date, index, ext, gzip]
+    : [name, ext, date, index, gzip];
+
+  return ({ date, index }) => {
+    debug(`_formatFileName: date=${date}, index=${index}`);
+    return parts.reduce((filename, part) => part(filename, index, date), "");
+  };
+};

--- a/lib/fileNameParser.js
+++ b/lib/fileNameParser.js
@@ -74,7 +74,7 @@ module.exports = ({ file, keepFileExt, pattern }) => {
   ];
 
   return filename => {
-    let result = { index: 0, isCompressed: false };
+    let result = { filename, index: 0, isCompressed: false };
     // pass the filename through each of the file part parsers
     let whatsLeftOver = parts.reduce(
       (remains, part) => part(remains, result),

--- a/lib/fileNameParser.js
+++ b/lib/fileNameParser.js
@@ -1,0 +1,86 @@
+const debug = require("debug")("streamroller:fileNameParser");
+const FILENAME_SEP = ".";
+const ZIP_EXT = ".gz";
+const _ = require("lodash");
+const format = require("date-format");
+
+module.exports = ({ file, keepFileExt, pattern }) => {
+  // All these functions take two arguments: f, the filename, and p, the result placeholder
+  // They return the filename with any matching parts removed.
+  // The "zip" function, for instance, removes the ".gz" part of the filename (if present)
+  const zip = (f, p) => {
+    if (_.endsWith(f, ZIP_EXT)) {
+      debug("it is gzipped");
+      p.isCompressed = true;
+      return f.slice(0, -1 * ZIP_EXT.length);
+    }
+    return f;
+  };
+
+  const extAtEnd = f => {
+    if (_.startsWith(f, file.name) && _.endsWith(f, file.ext)) {
+      debug("it starts and ends with the right things");
+      return f.slice(file.name.length + 1, -1 * file.ext.length);
+    }
+    return f;
+  };
+
+  const extInMiddle = f => {
+    if (_.startsWith(f, file.base)) {
+      debug("it starts with the right things");
+      return f.slice(file.base.length + 1);
+    }
+    return f;
+  };
+
+  const dateAndIndex = (f, p) => {
+    const items = _.split(f, FILENAME_SEP);
+    let indexStr = items[items.length - 1];
+    debug("items: ", items, ", indexStr: ", indexStr);
+    let dateStr = f;
+    if (indexStr !== undefined && indexStr.match(/^\d+$/)) {
+      dateStr = f.slice(0, -1 * (indexStr.length + 1));
+      debug(`dateStr is ${dateStr}`);
+    } else {
+      indexStr = "0";
+    }
+
+    try {
+      const date = format.parse(pattern, dateStr, new Date(0));
+      p.index = parseInt(indexStr, 10);
+      p.date = dateStr;
+      p.timestamp = date.getTime();
+      return "";
+    } catch (e) {
+      //not a valid date, don't panic.
+      debug(`Problem parsing ${dateStr} as ${pattern}, error was: `, e);
+      return f;
+    }
+  };
+
+  const index = (f, p) => {
+    if (f.match(/^\d+$/)) {
+      debug("it has an index");
+      p.index = parseInt(f, 10);
+      return "";
+    }
+    return f;
+  };
+
+  let parts = [
+    zip,
+    keepFileExt ? extAtEnd : extInMiddle,
+    pattern ? dateAndIndex : index
+  ];
+
+  return filename => {
+    let result = { index: 0, isCompressed: false };
+    // pass the filename through each of the file part parsers
+    let whatsLeftOver = parts.reduce(
+      (remains, part) => part(remains, result),
+      filename
+    );
+    // if there's anything left after parsing, then it wasn't a valid filename
+    return whatsLeftOver ? null : result;
+  };
+};

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "readmeFilename": "README.md",
   "gitHead": "ece35d7d86c87c04ff09e8604accae81cf36a0ce",
   "devDependencies": {
-    "@commitlint/cli": "^8.0.0",
-    "@commitlint/config-conventional": "^8.0.0",
+    "@commitlint/cli": "^8.1.0",
+    "@commitlint/config-conventional": "^8.1.0",
     "eslint": "^6.0.1",
     "husky": "^3.0.0",
     "mocha": "^6.1.4",
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "async": "^2.6.3",
-    "date-format": "^2.0.0",
+    "date-format": "^2.1.0",
     "debug": "^4.1.1",
     "fs-extra": "^8.1.0",
     "lodash": "^4.17.14"

--- a/test/fileNameFormatter-test.js
+++ b/test/fileNameFormatter-test.js
@@ -1,0 +1,495 @@
+require("should");
+
+describe("fileNameFormatter", () => {
+  describe("without a date", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      }
+    });
+    it("should take an index and return a filename", () => {
+      fileNameFormatter({
+        index: 0
+      }).should.eql("thefile.log");
+      fileNameFormatter({ index: 1, date: "" }).should.eql("thefile.log.1");
+      fileNameFormatter({ index: 15, date: undefined }).should.eql(
+        "thefile.log.15"
+      );
+      fileNameFormatter({ index: 15 }).should.eql("thefile.log.15");
+    });
+  });
+
+  describe("with a date", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      }
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({ index: 0, date: "2019-07-15" }).should.eql(
+        "thefile.log"
+      );
+      fileNameFormatter({
+        index: 2,
+        date: "2019-07-16"
+      }).should.eql("thefile.log.2019-07-16");
+    });
+  });
+
+  describe("with the alwaysIncludeDate option", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      alwaysIncludeDate: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.log.2019-07-15");
+      fileNameFormatter({ index: 0, date: "2019-07-15" }).should.eql(
+        "thefile.log.2019-07-15"
+      );
+      fileNameFormatter({
+        index: 2,
+        date: "2019-07-16"
+      }).should.eql("thefile.log.2019-07-16");
+    });
+  });
+
+  describe("with the keepFileExt option", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      keepFileExt: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.log");
+      fileNameFormatter({ index: 1 }).should.eql("thefile.1.log");
+      fileNameFormatter({ index: 2 }).should.eql("thefile.2.log");
+      fileNameFormatter({ index: 15 }).should.eql("thefile.15.log");
+    });
+  });
+
+  describe("with the keepFileExt option and a date", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      keepFileExt: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.log");
+      fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
+        "thefile.2019-07-15.log"
+      );
+      fileNameFormatter({
+        index: 2,
+        date: "2019-07-16"
+      }).should.eql("thefile.2019-07-16.log");
+    });
+  });
+
+  describe("with the keepFileExt, alwaysIncludeDate options", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      keepFileExt: true,
+      alwaysIncludeDate: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.2019-07-15.log");
+      fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
+        "thefile.2019-07-15.log"
+      );
+      fileNameFormatter({
+        index: 2,
+        date: "2019-07-16"
+      }).should.eql("thefile.2019-07-16.log");
+    });
+  });
+
+  describe("with the compress option", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      compress: true
+    });
+    it("should take an index and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.log");
+      fileNameFormatter({ index: 1 }).should.eql("thefile.log.1.gz");
+      fileNameFormatter({
+        index: 2
+      }).should.eql("thefile.log.2.gz");
+    });
+  });
+
+  describe("with the compress option and a date", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      compress: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.log");
+      fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
+        "thefile.log.2019-07-15.gz"
+      );
+      fileNameFormatter({
+        index: 2,
+        date: "2019-07-16"
+      }).should.eql("thefile.log.2019-07-16.gz");
+    });
+  });
+
+  describe("with the compress, alwaysIncludeDate option and a date", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      compress: true,
+      alwaysIncludeDate: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.log.2019-07-15");
+      fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
+        "thefile.log.2019-07-15.gz"
+      );
+      fileNameFormatter({
+        index: 2,
+        date: "2019-07-16"
+      }).should.eql("thefile.log.2019-07-16.gz");
+    });
+  });
+
+  describe("with the compress, alwaysIncludeDate, keepFileExt option and a date", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      compress: true,
+      alwaysIncludeDate: true,
+      keepFileExt: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.2019-07-15.log");
+      fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
+        "thefile.2019-07-15.log.gz"
+      );
+      fileNameFormatter({
+        index: 2,
+        date: "2019-07-16"
+      }).should.eql("thefile.2019-07-16.log.gz");
+    });
+  });
+
+  describe("with the needsIndex option", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      compress: true,
+      needsIndex: true,
+      alwaysIncludeDate: true,
+      keepFileExt: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.2019-07-15.log");
+      fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
+        "thefile.2019-07-15.1.log.gz"
+      );
+      fileNameFormatter({
+        index: 2,
+        date: "2019-07-16"
+      }).should.eql("thefile.2019-07-16.2.log.gz");
+    });
+  });
+
+  describe("with a date and needsIndex", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      needsIndex: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({ index: 0, date: "2019-07-15" }).should.eql(
+        "thefile.log"
+      );
+      fileNameFormatter({
+        index: 2,
+        date: "2019-07-16"
+      }).should.eql("thefile.log.2019-07-16.2");
+    });
+  });
+
+  describe("with the alwaysIncludeDate, needsIndex option", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      needsIndex: true,
+      alwaysIncludeDate: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.log.2019-07-15");
+      fileNameFormatter({ index: 0, date: "2019-07-15" }).should.eql(
+        "thefile.log.2019-07-15"
+      );
+      fileNameFormatter({
+        index: 2,
+        date: "2019-07-16"
+      }).should.eql("thefile.log.2019-07-16.2");
+    });
+  });
+
+  describe("with the keepFileExt, needsIndex option", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      needsIndex: true,
+      keepFileExt: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.log");
+      fileNameFormatter({ index: 1 }).should.eql("thefile.1.log");
+      fileNameFormatter({ index: 2 }).should.eql("thefile.2.log");
+      fileNameFormatter({ index: 15 }).should.eql("thefile.15.log");
+    });
+  });
+
+  describe("with the keepFileExt, needsIndex option and a date", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      needsIndex: true,
+      keepFileExt: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.log");
+      fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
+        "thefile.2019-07-15.1.log"
+      );
+      fileNameFormatter({
+        index: 2,
+        date: "2019-07-16"
+      }).should.eql("thefile.2019-07-16.2.log");
+    });
+  });
+
+  describe("with the keepFileExt, needsIndex, alwaysIncludeDate options", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      needsIndex: true,
+      keepFileExt: true,
+      alwaysIncludeDate: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.2019-07-15.log");
+      fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
+        "thefile.2019-07-15.1.log"
+      );
+      fileNameFormatter({
+        index: 2,
+        date: "2019-07-16"
+      }).should.eql("thefile.2019-07-16.2.log");
+    });
+  });
+
+  describe("with the compress, needsIndex option", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      needsIndex: true,
+      compress: true
+    });
+    it("should take an index and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.log");
+      fileNameFormatter({ index: 1 }).should.eql("thefile.log.1.gz");
+      fileNameFormatter({
+        index: 2
+      }).should.eql("thefile.log.2.gz");
+    });
+  });
+
+  describe("with the compress, needsIndex option and a date", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      needsIndex: true,
+      compress: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.log");
+      fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
+        "thefile.log.2019-07-15.1.gz"
+      );
+      fileNameFormatter({
+        index: 2,
+        date: "2019-07-16"
+      }).should.eql("thefile.log.2019-07-16.2.gz");
+    });
+  });
+
+  describe("with the compress, alwaysIncludeDate, needsIndex option and a date", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      needsIndex: true,
+      compress: true,
+      alwaysIncludeDate: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.log.2019-07-15");
+      fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
+        "thefile.log.2019-07-15.1.gz"
+      );
+      fileNameFormatter({
+        index: 2,
+        date: "2019-07-16"
+      }).should.eql("thefile.log.2019-07-16.2.gz");
+    });
+  });
+
+  describe("with the compress, alwaysIncludeDate, keepFileExt, needsIndex option and a date", () => {
+    const fileNameFormatter = require("../lib/fileNameFormatter")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      needsIndex: true,
+      compress: true,
+      alwaysIncludeDate: true,
+      keepFileExt: true
+    });
+    it("should take an index, date and return a filename", () => {
+      fileNameFormatter({
+        index: 0,
+        date: "2019-07-15"
+      }).should.eql("thefile.2019-07-15.log");
+      fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
+        "thefile.2019-07-15.1.log.gz"
+      );
+      fileNameFormatter({
+        index: 2,
+        date: "2019-07-16"
+      }).should.eql("thefile.2019-07-16.2.log.gz");
+    });
+  });
+});

--- a/test/fileNameFormatter-test.js
+++ b/test/fileNameFormatter-test.js
@@ -13,12 +13,16 @@ describe("fileNameFormatter", () => {
     it("should take an index and return a filename", () => {
       fileNameFormatter({
         index: 0
-      }).should.eql("thefile.log");
-      fileNameFormatter({ index: 1, date: "" }).should.eql("thefile.log.1");
-      fileNameFormatter({ index: 15, date: undefined }).should.eql(
-        "thefile.log.15"
+      }).should.eql("/path/to/file/thefile.log");
+      fileNameFormatter({ index: 1, date: "" }).should.eql(
+        "/path/to/file/thefile.log.1"
       );
-      fileNameFormatter({ index: 15 }).should.eql("thefile.log.15");
+      fileNameFormatter({ index: 15, date: undefined }).should.eql(
+        "/path/to/file/thefile.log.15"
+      );
+      fileNameFormatter({ index: 15 }).should.eql(
+        "/path/to/file/thefile.log.15"
+      );
     });
   });
 
@@ -33,12 +37,12 @@ describe("fileNameFormatter", () => {
     });
     it("should take an index, date and return a filename", () => {
       fileNameFormatter({ index: 0, date: "2019-07-15" }).should.eql(
-        "thefile.log"
+        "/path/to/file/thefile.log"
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("thefile.log.2019-07-16");
+      }).should.eql("/path/to/file/thefile.log.2019-07-16");
     });
   });
 
@@ -56,14 +60,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.log.2019-07-15");
+      }).should.eql("/path/to/file/thefile.log.2019-07-15");
       fileNameFormatter({ index: 0, date: "2019-07-15" }).should.eql(
-        "thefile.log.2019-07-15"
+        "/path/to/file/thefile.log.2019-07-15"
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("thefile.log.2019-07-16");
+      }).should.eql("/path/to/file/thefile.log.2019-07-16");
     });
   });
 
@@ -81,10 +85,12 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.log");
-      fileNameFormatter({ index: 1 }).should.eql("thefile.1.log");
-      fileNameFormatter({ index: 2 }).should.eql("thefile.2.log");
-      fileNameFormatter({ index: 15 }).should.eql("thefile.15.log");
+      }).should.eql("/path/to/file/thefile.log");
+      fileNameFormatter({ index: 1 }).should.eql("/path/to/file/thefile.1.log");
+      fileNameFormatter({ index: 2 }).should.eql("/path/to/file/thefile.2.log");
+      fileNameFormatter({ index: 15 }).should.eql(
+        "/path/to/file/thefile.15.log"
+      );
     });
   });
 
@@ -102,14 +108,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.log");
+      }).should.eql("/path/to/file/thefile.log");
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "thefile.2019-07-15.log"
+        "/path/to/file/thefile.2019-07-15.log"
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("thefile.2019-07-16.log");
+      }).should.eql("/path/to/file/thefile.2019-07-16.log");
     });
   });
 
@@ -128,14 +134,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.2019-07-15.log");
+      }).should.eql("/path/to/file/thefile.2019-07-15.log");
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "thefile.2019-07-15.log"
+        "/path/to/file/thefile.2019-07-15.log"
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("thefile.2019-07-16.log");
+      }).should.eql("/path/to/file/thefile.2019-07-16.log");
     });
   });
 
@@ -153,11 +159,13 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.log");
-      fileNameFormatter({ index: 1 }).should.eql("thefile.log.1.gz");
+      }).should.eql("/path/to/file/thefile.log");
+      fileNameFormatter({ index: 1 }).should.eql(
+        "/path/to/file/thefile.log.1.gz"
+      );
       fileNameFormatter({
         index: 2
-      }).should.eql("thefile.log.2.gz");
+      }).should.eql("/path/to/file/thefile.log.2.gz");
     });
   });
 
@@ -175,14 +183,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.log");
+      }).should.eql("/path/to/file/thefile.log");
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "thefile.log.2019-07-15.gz"
+        "/path/to/file/thefile.log.2019-07-15.gz"
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("thefile.log.2019-07-16.gz");
+      }).should.eql("/path/to/file/thefile.log.2019-07-16.gz");
     });
   });
 
@@ -201,14 +209,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.log.2019-07-15");
+      }).should.eql("/path/to/file/thefile.log.2019-07-15");
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "thefile.log.2019-07-15.gz"
+        "/path/to/file/thefile.log.2019-07-15.gz"
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("thefile.log.2019-07-16.gz");
+      }).should.eql("/path/to/file/thefile.log.2019-07-16.gz");
     });
   });
 
@@ -228,14 +236,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.2019-07-15.log");
+      }).should.eql("/path/to/file/thefile.2019-07-15.log");
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "thefile.2019-07-15.log.gz"
+        "/path/to/file/thefile.2019-07-15.log.gz"
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("thefile.2019-07-16.log.gz");
+      }).should.eql("/path/to/file/thefile.2019-07-16.log.gz");
     });
   });
 
@@ -256,14 +264,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.2019-07-15.log");
+      }).should.eql("/path/to/file/thefile.2019-07-15.log");
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "thefile.2019-07-15.1.log.gz"
+        "/path/to/file/thefile.2019-07-15.1.log.gz"
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("thefile.2019-07-16.2.log.gz");
+      }).should.eql("/path/to/file/thefile.2019-07-16.2.log.gz");
     });
   });
 
@@ -279,12 +287,12 @@ describe("fileNameFormatter", () => {
     });
     it("should take an index, date and return a filename", () => {
       fileNameFormatter({ index: 0, date: "2019-07-15" }).should.eql(
-        "thefile.log"
+        "/path/to/file/thefile.log"
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("thefile.log.2019-07-16.2");
+      }).should.eql("/path/to/file/thefile.log.2019-07-16.2");
     });
   });
 
@@ -303,14 +311,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.log.2019-07-15");
+      }).should.eql("/path/to/file/thefile.log.2019-07-15");
       fileNameFormatter({ index: 0, date: "2019-07-15" }).should.eql(
-        "thefile.log.2019-07-15"
+        "/path/to/file/thefile.log.2019-07-15"
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("thefile.log.2019-07-16.2");
+      }).should.eql("/path/to/file/thefile.log.2019-07-16.2");
     });
   });
 
@@ -329,10 +337,12 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.log");
-      fileNameFormatter({ index: 1 }).should.eql("thefile.1.log");
-      fileNameFormatter({ index: 2 }).should.eql("thefile.2.log");
-      fileNameFormatter({ index: 15 }).should.eql("thefile.15.log");
+      }).should.eql("/path/to/file/thefile.log");
+      fileNameFormatter({ index: 1 }).should.eql("/path/to/file/thefile.1.log");
+      fileNameFormatter({ index: 2 }).should.eql("/path/to/file/thefile.2.log");
+      fileNameFormatter({ index: 15 }).should.eql(
+        "/path/to/file/thefile.15.log"
+      );
     });
   });
 
@@ -351,14 +361,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.log");
+      }).should.eql("/path/to/file/thefile.log");
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "thefile.2019-07-15.1.log"
+        "/path/to/file/thefile.2019-07-15.1.log"
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("thefile.2019-07-16.2.log");
+      }).should.eql("/path/to/file/thefile.2019-07-16.2.log");
     });
   });
 
@@ -378,14 +388,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.2019-07-15.log");
+      }).should.eql("/path/to/file/thefile.2019-07-15.log");
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "thefile.2019-07-15.1.log"
+        "/path/to/file/thefile.2019-07-15.1.log"
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("thefile.2019-07-16.2.log");
+      }).should.eql("/path/to/file/thefile.2019-07-16.2.log");
     });
   });
 
@@ -404,11 +414,13 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.log");
-      fileNameFormatter({ index: 1 }).should.eql("thefile.log.1.gz");
+      }).should.eql("/path/to/file/thefile.log");
+      fileNameFormatter({ index: 1 }).should.eql(
+        "/path/to/file/thefile.log.1.gz"
+      );
       fileNameFormatter({
         index: 2
-      }).should.eql("thefile.log.2.gz");
+      }).should.eql("/path/to/file/thefile.log.2.gz");
     });
   });
 
@@ -427,14 +439,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.log");
+      }).should.eql("/path/to/file/thefile.log");
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "thefile.log.2019-07-15.1.gz"
+        "/path/to/file/thefile.log.2019-07-15.1.gz"
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("thefile.log.2019-07-16.2.gz");
+      }).should.eql("/path/to/file/thefile.log.2019-07-16.2.gz");
     });
   });
 
@@ -454,14 +466,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.log.2019-07-15");
+      }).should.eql("/path/to/file/thefile.log.2019-07-15");
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "thefile.log.2019-07-15.1.gz"
+        "/path/to/file/thefile.log.2019-07-15.1.gz"
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("thefile.log.2019-07-16.2.gz");
+      }).should.eql("/path/to/file/thefile.log.2019-07-16.2.gz");
     });
   });
 
@@ -482,14 +494,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("thefile.2019-07-15.log");
+      }).should.eql("/path/to/file/thefile.2019-07-15.log");
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "thefile.2019-07-15.1.log.gz"
+        "/path/to/file/thefile.2019-07-15.1.log.gz"
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("thefile.2019-07-16.2.log.gz");
+      }).should.eql("/path/to/file/thefile.2019-07-16.2.log.gz");
     });
   });
 });

--- a/test/fileNameParser-test.js
+++ b/test/fileNameParser-test.js
@@ -1,0 +1,83 @@
+const should = require("should");
+
+describe("fileNameParser", () => {
+  describe("with default options", () => {
+    const parser = require("../lib/fileNameParser")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      }
+    });
+    it("should return null for filenames that do not match", () => {
+      should(parser("cheese.txt")).not.be.ok();
+      should(parser("thefile.log.biscuits")).not.be.ok();
+    });
+    it("should take a filename and return the index", () => {
+      parser("thefile.log.2").should.eql({ index: 2, isCompressed: false });
+      parser("thefile.log.2.gz").should.eql({ index: 2, isCompressed: true });
+    });
+  });
+
+  describe("with pattern option", () => {
+    const parser = require("../lib/fileNameParser")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      pattern: "yyyy-MM-dd"
+    });
+    it("should return null for files that do not match", () => {
+      should(parser("thefile.log.biscuits")).not.be.ok();
+      should(parser("thefile.log.2019")).not.be.ok();
+      should(parser("thefile.log.3.2")).not.be.ok();
+    });
+    it("should take a filename and return the date", () => {
+      parser("thefile.log.2019-07-17").should.eql({
+        index: 0,
+        date: "2019-07-17",
+        timestamp: 1563321600000,
+        isCompressed: false
+      });
+      parser("thefile.log.gz").should.eql({
+        index: 0,
+        isCompressed: true
+      });
+    });
+    it("should take a filename and return both date and index", () => {
+      parser("thefile.log.2019-07-17.2").should.eql({
+        index: 2,
+        date: "2019-07-17",
+        timestamp: 1563321600000,
+        isCompressed: false
+      });
+      parser("thefile.log.2019-07-17.2.gz").should.eql({
+        index: 2,
+        date: "2019-07-17",
+        timestamp: 1563321600000,
+        isCompressed: true
+      });
+    });
+  });
+
+  describe("with keepFileExt option", () => {
+    const parser = require("../lib/fileNameParser")({
+      file: {
+        dir: "/path/to/file",
+        base: "thefile.log",
+        ext: ".log",
+        name: "thefile"
+      },
+      keepFileExt: true
+    });
+    it("should take a filename and return the index", () => {
+      should(parser("thefile.log.2")).not.be.ok();
+      should(parser("thefile.log.2.gz")).not.be.ok();
+      parser("thefile.2.log").should.eql({ index: 2, isCompressed: false });
+      parser("thefile.2.log.gz").should.eql({ index: 2, isCompressed: true });
+    });
+  });
+});

--- a/test/fileNameParser-test.js
+++ b/test/fileNameParser-test.js
@@ -15,8 +15,16 @@ describe("fileNameParser", () => {
       should(parser("thefile.log.biscuits")).not.be.ok();
     });
     it("should take a filename and return the index", () => {
-      parser("thefile.log.2").should.eql({ index: 2, isCompressed: false });
-      parser("thefile.log.2.gz").should.eql({ index: 2, isCompressed: true });
+      parser("thefile.log.2").should.eql({
+        filename: "thefile.log.2",
+        index: 2,
+        isCompressed: false
+      });
+      parser("thefile.log.2.gz").should.eql({
+        filename: "thefile.log.2.gz",
+        index: 2,
+        isCompressed: true
+      });
     });
   });
 
@@ -37,24 +45,28 @@ describe("fileNameParser", () => {
     });
     it("should take a filename and return the date", () => {
       parser("thefile.log.2019-07-17").should.eql({
+        filename: "thefile.log.2019-07-17",
         index: 0,
         date: "2019-07-17",
         timestamp: 1563321600000,
         isCompressed: false
       });
       parser("thefile.log.gz").should.eql({
+        filename: "thefile.log.gz",
         index: 0,
         isCompressed: true
       });
     });
     it("should take a filename and return both date and index", () => {
       parser("thefile.log.2019-07-17.2").should.eql({
+        filename: "thefile.log.2019-07-17.2",
         index: 2,
         date: "2019-07-17",
         timestamp: 1563321600000,
         isCompressed: false
       });
       parser("thefile.log.2019-07-17.2.gz").should.eql({
+        filename: "thefile.log.2019-07-17.2.gz",
         index: 2,
         date: "2019-07-17",
         timestamp: 1563321600000,
@@ -76,8 +88,16 @@ describe("fileNameParser", () => {
     it("should take a filename and return the index", () => {
       should(parser("thefile.log.2")).not.be.ok();
       should(parser("thefile.log.2.gz")).not.be.ok();
-      parser("thefile.2.log").should.eql({ index: 2, isCompressed: false });
-      parser("thefile.2.log.gz").should.eql({ index: 2, isCompressed: true });
+      parser("thefile.2.log").should.eql({
+        filename: "thefile.2.log",
+        index: 2,
+        isCompressed: false
+      });
+      parser("thefile.2.log.gz").should.eql({
+        filename: "thefile.2.log.gz",
+        index: 2,
+        isCompressed: true
+      });
     });
   });
 });


### PR DESCRIPTION
I've replaced `_formatFileName` and `_parseFileName` with two new functions loaded from different modules. I think it makes the code easier to understand (and also should fix a bug where you could get errors if files existed that had dates which could not be parsed in them). 