### PR TITLE
refactor: moved async to dev-only dependency

### DIFF
--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -1,5 +1,4 @@
 const debug = require("debug")("streamroller:RollingFileWriteStream");
-const async = require("async");
 const fs = require("fs-extra");
 const zlib = require("zlib");
 const path = require("path");
@@ -9,25 +8,19 @@ const { Writable } = require("stream");
 const fileNameFormatter = require("./fileNameFormatter");
 const fileNameParser = require("./fileNameParser");
 
-const moveAndMaybeCompressFile = (
+const moveAndMaybeCompressFile = async (
   sourceFilePath,
   targetFilePath,
-  needCompress,
-  done
+  needCompress
 ) => {
   if (sourceFilePath === targetFilePath) {
     debug(
       `moveAndMaybeCompressFile: source and target are the same, not doing anything`
     );
-    return done();
+    return;
   }
-  fs.access(sourceFilePath, fs.constants.W_OK | fs.constants.R_OK, e => {
-    if (e) {
-      debug(
-        `moveAndMaybeCompressFile: source file path does not exist. not moving. sourceFilePath=${sourceFilePath}`
-      );
-      return done();
-    }
+  try {
+    await fs.access(sourceFilePath, fs.constants.W_OK | fs.constants.R_OK);
 
     debug(
       `moveAndMaybeCompressFile: moving file from ${sourceFilePath} to ${targetFilePath} ${
@@ -35,24 +28,38 @@ const moveAndMaybeCompressFile = (
       } compress`
     );
     if (needCompress) {
-      fs.createReadStream(sourceFilePath)
-        .pipe(zlib.createGzip())
-        .pipe(fs.createWriteStream(targetFilePath))
-        .on("finish", () => {
-          debug(
-            `moveAndMaybeCompressFile: finished compressing ${targetFilePath}, deleting ${sourceFilePath}`
-          );
-          fs.unlink(sourceFilePath, done);
-        });
+      await new Promise((resolve, reject) => {
+        fs.createReadStream(sourceFilePath)
+          .pipe(zlib.createGzip())
+          .pipe(fs.createWriteStream(targetFilePath))
+          .on("finish", () => {
+            debug(
+              `moveAndMaybeCompressFile: finished compressing ${targetFilePath}, deleting ${sourceFilePath}`
+            );
+            fs.unlink(sourceFilePath)
+              .then(resolve)
+              .catch(reject);
+          });
+      });
     } else {
       debug(
         `moveAndMaybeCompressFile: deleting file=${targetFilePath}, renaming ${sourceFilePath} to ${targetFilePath}`
       );
-      fs.unlink(targetFilePath, () => {
-        fs.rename(sourceFilePath, targetFilePath, done);
+      await fs.unlink(targetFilePath).catch(() => {
+        /* doesn't matter */
       });
+      await fs.rename(sourceFilePath, targetFilePath);
     }
-  });
+  } catch (e) {
+    debug(
+      `moveAndMaybeCompressFile: source file path does not exist. not moving. sourceFilePath=${sourceFilePath}`
+    );
+  }
+};
+
+const deleteFiles = fileNames => {
+  debug(`files to delete: ${fileNames}`);
+  return Promise.all(fileNames.map(f => fs.unlink(f)));
 };
 
 /**
@@ -167,19 +174,17 @@ class RollingFileWriteStream extends Writable {
     return this.state.currentSize >= this.options.maxSize;
   }
 
-  _shouldRoll(callback) {
+  async _shouldRoll() {
     if (this._dateChanged() || this._tooBig()) {
       debug(
         `rolling because dateChanged? ${this._dateChanged()} or tooBig? ${this._tooBig()}`
       );
-      this._roll(callback);
-      return;
+      await this._roll();
     }
-    callback();
   }
 
   _write(chunk, encoding, callback) {
-    this._shouldRoll(() => {
+    this._shouldRoll().then(() => {
       debug(
         `writing chunk. ` +
           `file=${this.currentFileStream.path} ` +
@@ -194,78 +199,74 @@ class RollingFileWriteStream extends Writable {
   }
 
   // Sorted from the oldest to the latest
-  _getExistingFiles(cb) {
-    fs.readdir(this.fileObject.dir, (e, files) => {
-      debug(`_getExistingFiles: files=${files}`);
-      const existingFileDetails = (files || [])
-        .map(n => this.fileNameParser(n))
-        .filter(n => n !== undefined && n !== null);
+  async _getExistingFiles() {
+    const files = await fs.readdir(this.fileObject.dir).catch(() => []);
 
-      const getKey = n => (n.timestamp ? n.timestamp : newNow().getTime()) - n.index
-      existingFileDetails.sort((a, b) => getKey(a) - getKey(b))
+    debug(`_getExistingFiles: files=${files}`);
+    const existingFileDetails = files
+      .map(n => this.fileNameParser(n))
+      .filter(n => n);
 
-      cb(null, existingFileDetails);
-    });
+    const getKey = n =>
+      (n.timestamp ? n.timestamp : newNow().getTime()) - n.index;
+    existingFileDetails.sort((a, b) => getKey(a) - getKey(b));
+
+    return existingFileDetails;
   }
 
-  _moveOldFiles(cb) {
+  async _moveOldFiles() {
     const currentFilePath = this.currentFileStream.path;
 
-    this._getExistingFiles((e, files) => {
-      const filesToMove = [];
-      const todaysFiles = this.state.currentDate
-        ? files.filter(f => f.date === this.state.currentDate)
-        : files;
-      for (let i = todaysFiles.length; i >= 0; i--) {
-        debug(`i = ${i}`);
-        const sourceFilePath =
-          i === 0
-            ? currentFilePath
-            : this.fileFormatter({
-                date: this.state.currentDate,
-                index: i
-              });
-        const targetFilePath = this.fileFormatter({
-          date: this.state.currentDate,
-          index: i + 1
-        });
-        filesToMove.push({ sourceFilePath, targetFilePath });
-      }
-      debug(`filesToMove = `, filesToMove);
-      async.eachOfSeries(
-        filesToMove,
-        (files, idx, cb1) => {
-          debug(
-            `src=${files.sourceFilePath}, tgt=${
-              files.sourceFilePath
-            }, idx=${idx}, pos=${filesToMove.length - 1 - idx}`
-          );
-          moveAndMaybeCompressFile(
-            files.sourceFilePath,
-            files.targetFilePath,
-            this.options.compress && filesToMove.length - 1 - idx === 0,
-            cb1
-          );
-        },
-        () => {
-          this.state.currentSize = 0;
-          this.state.currentDate = this.state.currentDate
-            ? format(this.options.pattern, newNow())
-            : null;
-          debug(`finished rolling files. state=${JSON.stringify(this.state)}`);
-          this._renewWriteStream();
-          // wait for the file to be open before cleaning up old ones,
-          // otherwise the daysToKeep calculations can be off
-          this.currentFileStream.write("", "utf8", () => this._clean(cb));
-        }
+    const files = await this._getExistingFiles();
+    const todaysFiles = this.state.currentDate
+      ? files.filter(f => f.date === this.state.currentDate)
+      : files;
+    for (let i = todaysFiles.length; i >= 0; i--) {
+      debug(`i = ${i}`);
+      const sourceFilePath =
+        i === 0
+          ? currentFilePath
+          : this.fileFormatter({
+              date: this.state.currentDate,
+              index: i
+            });
+      const targetFilePath = this.fileFormatter({
+        date: this.state.currentDate,
+        index: i + 1
+      });
+
+      await moveAndMaybeCompressFile(
+        sourceFilePath,
+        targetFilePath,
+        this.options.compress && i === 0
       );
+    }
+
+    this.state.currentSize = 0;
+    this.state.currentDate = this.state.currentDate
+      ? format(this.options.pattern, newNow())
+      : null;
+    debug(`finished rolling files. state=${JSON.stringify(this.state)}`);
+    this._renewWriteStream();
+    // wait for the file to be open before cleaning up old ones,
+    // otherwise the daysToKeep calculations can be off
+    await new Promise((resolve, reject) => {
+      this.currentFileStream.write("", "utf8", () => {
+        this._clean()
+          .then(resolve)
+          .catch(reject);
+      });
     });
   }
 
-  _roll(cb) {
+  _roll() {
     debug(`_roll: closing the current stream`);
-    this.currentFileStream.end("", this.options.encoding, () => {
-      this._moveOldFiles(cb);
+    return new Promise((resolve, reject) => {
+      this.currentFileStream.end("", this.options.encoding, () => {
+        this._moveOldFiles()
+          .then(resolve)
+          .catch(reject);
+      });
     });
   }
 
@@ -278,7 +279,7 @@ class RollingFileWriteStream extends Writable {
     const ops = {
       flags: this.options.flags,
       encoding: this.options.encoding,
-      mode: this.options.mode,
+      mode: this.options.mode
     };
     this.currentFileStream = fs.createWriteStream(filePath, ops);
     this.currentFileStream.on("error", e => {
@@ -286,35 +287,24 @@ class RollingFileWriteStream extends Writable {
     });
   }
 
-  _clean(cb) {
-    this._getExistingFiles((e, existingFileDetails) => {
-      debug(
-        `numToKeep = ${this.options.numToKeep}, existingFiles = ${existingFileDetails.length}`
-      );
-      debug("existing files are: ", existingFileDetails);
-      if (
-        this.options.numToKeep > 0 &&
-        existingFileDetails.length > this.options.numToKeep
-      ) {
-        const fileNamesToRemove = existingFileDetails.map(f => f.filename).slice(
-          0,
-          existingFileDetails.length - this.options.numToKeep - 1
-        );
-        this._deleteFiles(fileNamesToRemove, cb);
-        return;
-      }
-      cb();
-    });
+  _tooManyFiles(numFiles) {
+    return (
+      this.options.numToKeep > 0 && numFiles.length > this.options.numToKeep
+    );
   }
 
-  _deleteFiles(fileNames, done) {
-    debug(`files to delete: ${fileNames}`);
-    async.each(
-      fileNames.map(f => path.format({ dir: this.fileObject.dir, base: f })),
-      fs.unlink,
-      done
+  async _clean() {
+    const existingFileDetails = await this._getExistingFiles();
+    debug(
+      `numToKeep = ${this.options.numToKeep}, existingFiles = ${existingFileDetails.length}`
     );
-    return;
+    debug("existing files are: ", existingFileDetails);
+    if (this._tooManyFiles(existingFileDetails.length)) {
+      const fileNamesToRemove = existingFileDetails
+        .map(f => path.format({ dir: this.fileObject.dir, base: f.filename }))
+        .slice(0, existingFileDetails.length - this.options.numToKeep - 1);
+      await deleteFiles(fileNamesToRemove);
+    }
   }
 }
 

--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -288,9 +288,7 @@ class RollingFileWriteStream extends Writable {
   }
 
   _tooManyFiles(numFiles) {
-    return (
-      this.options.numToKeep > 0 && numFiles.length > this.options.numToKeep
-    );
+    return this.options.numToKeep > 0 && numFiles > this.options.numToKeep;
   }
 
   async _clean() {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
+    "async": "^2.6.3",
     "eslint": "^6.0.1",
     "husky": "^3.0.0",
     "mocha": "^6.1.4",
@@ -37,7 +38,6 @@
     "should": "^13.2.3"
   },
   "dependencies": {
-    "async": "^2.6.3",
     "date-format": "^2.1.0",
     "debug": "^4.1.1",
     "fs-extra": "^8.1.0"


### PR DESCRIPTION
Inspired by PR #45 (thanks @devoto13 ) - I've removed the async library from the main code. It is still used in the tests, so it's now moved to a dev dependency. I took the opportunity to use async/await now that we don't have to support node v6.