### PR TITLE
fix: fix date parsing and made tests not timezone sensitive

### DIFF
--- a/lib/fileNameParser.js
+++ b/lib/fileNameParser.js
@@ -45,7 +45,10 @@ module.exports = ({ file, keepFileExt, pattern }) => {
     }
 
     try {
-      const date = format.parse(pattern, dateStr, new Date(0));
+      // Two arguments for new Date() are intentional. This will set other date
+      // components to minimal values in the current timezone instead of UTC,
+      // as new Date(0) will do.
+      const date = format.parse(pattern, dateStr, new Date(0, 0));
       p.index = parseInt(indexStr, 10);
       p.date = dateStr;
       p.timestamp = date.getTime();

--- a/test/fileNameParser-test.js
+++ b/test/fileNameParser-test.js
@@ -48,7 +48,7 @@ describe("fileNameParser", () => {
         filename: "thefile.log.2019-07-17",
         index: 0,
         date: "2019-07-17",
-        timestamp: 1563321600000,
+        timestamp: new Date(2019, 6, 17).getTime(),
         isCompressed: false
       });
       parser("thefile.log.gz").should.eql({
@@ -62,14 +62,14 @@ describe("fileNameParser", () => {
         filename: "thefile.log.2019-07-17.2",
         index: 2,
         date: "2019-07-17",
-        timestamp: 1563321600000,
+        timestamp: new Date(2019, 6, 17).getTime(),
         isCompressed: false
       });
       parser("thefile.log.2019-07-17.2.gz").should.eql({
         filename: "thefile.log.2019-07-17.2.gz",
         index: 2,
         date: "2019-07-17",
-        timestamp: 1563321600000,
+        timestamp: new Date(2019, 6, 17).getTime(),
         isCompressed: true
       });
     });


### PR DESCRIPTION
See https://github.com/log4js-node/streamroller/pull/45#issuecomment-515999445 for the reasoning behind the change.