### PR TITLE
fix: added extra flag values that need size

### DIFF
--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -116,7 +116,7 @@ class RollingFileWriteStream extends Writable {
       index: 0,
       date: this.state.currentDate
     });
-    if (this.options.flags === "a") {
+    if (["a", "a+", "as", "as+"].includes(this.options.flags)) {
       this._setExistingSizeAndDate();
     }
 


### PR DESCRIPTION
The code that looks up the existing file size and timestamp was only checking when the flag was "a" (append). There are other flag values that also mean append, and should look up the current size when used.