### PR TITLE
Tidying up

### DIFF
--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -8,6 +8,251 @@ const { Writable } = require("stream");
 const fileNameFormatter = require("./fileNameFormatter");
 const fileNameParser = require("./fileNameParser");
 
+/**
+ * RollingFileWriteStream is mainly used when writing to a file rolling by date or size.
+ * RollingFileWriteStream inherits from stream.Writable
+ */
+class RollingFileWriteStream extends Writable {
+  /**
+   * Create a RollingFileWriteStream
+   * @constructor
+   * @param {string} filePath - The file path to write.
+   * @param {object} options - The extra options
+   * @param {number} options.numToKeep - The max numbers of files to keep.
+   * @param {number} options.maxSize - The maxSize one file can reach. Unit is Byte.
+   *                                   This should be more than 1024. The default is Number.MAX_SAFE_INTEGER.
+   * @param {string} options.mode - The mode of the files. The default is '0644'. Refer to stream.writable for more.
+   * @param {string} options.flags - The default is 'a'. Refer to stream.flags for more.
+   * @param {boolean} options.compress - Whether to compress backup files.
+   * @param {boolean} options.keepFileExt - Whether to keep the file extension.
+   * @param {string} options.pattern - The date string pattern in the file name.
+   * @param {boolean} options.alwaysIncludePattern - Whether to add date to the name of the first file.
+   */
+  constructor(filePath, options) {
+    debug(`constructor: creating RollingFileWriteStream. path=${filePath}`);
+    super(options);
+    this.options = this._parseOption(options);
+    this.fileObject = path.parse(filePath);
+    if (this.fileObject.dir === "") {
+      this.fileObject = path.parse(path.join(process.cwd(), filePath));
+    }
+    this.fileFormatter = fileNameFormatter({
+      file: this.fileObject,
+      alwaysIncludeDate: this.options.alwaysIncludePattern,
+      needsIndex: this.options.maxSize < Number.MAX_SAFE_INTEGER,
+      compress: this.options.compress,
+      keepFileExt: this.options.keepFileExt
+    });
+
+    this.fileNameParser = fileNameParser({
+      file: this.fileObject,
+      keepFileExt: this.options.keepFileExt,
+      pattern: this.options.pattern
+    });
+
+    this.state = {
+      currentSize: 0
+    };
+
+    if (this.options.pattern) {
+      this.state.currentDate = format(this.options.pattern, newNow());
+    }
+
+    this.filename = this.fileFormatter({
+      index: 0,
+      date: this.state.currentDate
+    });
+    if (["a", "a+", "as", "as+"].includes(this.options.flags)) {
+      this._setExistingSizeAndDate();
+    }
+
+    debug(
+      `constructor: create new file ${this.filename}, state=${JSON.stringify(
+        this.state
+      )}`
+    );
+    this._renewWriteStream();
+  }
+
+  _setExistingSizeAndDate() {
+    try {
+      const stats = fs.statSync(this.filename);
+      this.state.currentSize = stats.size;
+      if (this.options.pattern) {
+        this.state.currentDate = format(this.options.pattern, stats.birthtime);
+      }
+    } catch (e) {
+      //file does not exist, that's fine - move along
+      return;
+    }
+  }
+
+  _parseOption(rawOptions) {
+    const defaultOptions = {
+      maxSize: Number.MAX_SAFE_INTEGER,
+      numToKeep: Number.MAX_SAFE_INTEGER,
+      encoding: "utf8",
+      mode: parseInt("0644", 8),
+      flags: "a",
+      compress: false,
+      keepFileExt: false,
+      alwaysIncludePattern: false
+    };
+    const options = Object.assign({}, defaultOptions, rawOptions);
+    if (options.maxSize <= 0) {
+      throw new Error(`options.maxSize (${options.maxSize}) should be > 0`);
+    }
+    if (options.numToKeep <= 0) {
+      throw new Error(`options.numToKeep (${options.numToKeep}) should be > 0`);
+    }
+    debug(
+      `_parseOption: creating stream with option=${JSON.stringify(options)}`
+    );
+    return options;
+  }
+
+  _write(chunk, encoding, callback) {
+    this._shouldRoll().then(() => {
+      debug(
+        `_write: writing chunk. ` +
+          `file=${this.currentFileStream.path} ` +
+          `state=${JSON.stringify(this.state)} ` +
+          `chunk=${chunk}`
+      );
+      this.currentFileStream.write(chunk, encoding, e => {
+        this.state.currentSize += chunk.length;
+        callback(e);
+      });
+    });
+  }
+
+  async _shouldRoll() {
+    if (this._dateChanged() || this._tooBig()) {
+      debug(
+        `_shouldRoll: rolling because dateChanged? ${this._dateChanged()} or tooBig? ${this._tooBig()}`
+      );
+      await this._roll();
+    }
+  }
+
+  _dateChanged() {
+    return (
+      this.state.currentDate &&
+      this.state.currentDate !== format(this.options.pattern, newNow())
+    );
+  }
+
+  _tooBig() {
+    return this.state.currentSize >= this.options.maxSize;
+  }
+
+  _roll() {
+    debug(`_roll: closing the current stream`);
+    return new Promise((resolve, reject) => {
+      this.currentFileStream.end("", this.options.encoding, () => {
+        this._moveOldFiles()
+          .then(resolve)
+          .catch(reject);
+      });
+    });
+  }
+
+  async _moveOldFiles() {
+    const files = await this._getExistingFiles();
+    const todaysFiles = this.state.currentDate
+      ? files.filter(f => f.date === this.state.currentDate)
+      : files;
+    for (let i = todaysFiles.length; i >= 0; i--) {
+      debug(`_moveOldFiles: i = ${i}`);
+      const sourceFilePath = this.fileFormatter({
+        date: this.state.currentDate,
+        index: i
+      });
+      const targetFilePath = this.fileFormatter({
+        date: this.state.currentDate,
+        index: i + 1
+      });
+
+      await moveAndMaybeCompressFile(
+        sourceFilePath,
+        targetFilePath,
+        this.options.compress && i === 0
+      );
+    }
+
+    this.state.currentSize = 0;
+    this.state.currentDate = this.state.currentDate
+      ? format(this.options.pattern, newNow())
+      : null;
+    debug(
+      `_moveOldFiles: finished rolling files. state=${JSON.stringify(
+        this.state
+      )}`
+    );
+    this._renewWriteStream();
+    // wait for the file to be open before cleaning up old ones,
+    // otherwise the daysToKeep calculations can be off
+    await new Promise((resolve, reject) => {
+      this.currentFileStream.write("", "utf8", () => {
+        this._clean()
+          .then(resolve)
+          .catch(reject);
+      });
+    });
+  }
+
+  // Sorted from the oldest to the latest
+  async _getExistingFiles() {
+    const files = await fs.readdir(this.fileObject.dir).catch(() => []);
+
+    debug(`_getExistingFiles: files=${files}`);
+    const existingFileDetails = files
+      .map(n => this.fileNameParser(n))
+      .filter(n => n);
+
+    const getKey = n =>
+      (n.timestamp ? n.timestamp : newNow().getTime()) - n.index;
+    existingFileDetails.sort((a, b) => getKey(a) - getKey(b));
+
+    return existingFileDetails;
+  }
+
+  _renewWriteStream() {
+    fs.ensureDirSync(this.fileObject.dir);
+    const filePath = this.fileFormatter({
+      date: this.state.currentDate,
+      index: 0
+    });
+    const ops = {
+      flags: this.options.flags,
+      encoding: this.options.encoding,
+      mode: this.options.mode
+    };
+    this.currentFileStream = fs.createWriteStream(filePath, ops);
+    this.currentFileStream.on("error", e => {
+      this.emit("error", e);
+    });
+  }
+
+  async _clean() {
+    const existingFileDetails = await this._getExistingFiles();
+    debug(
+      `_clean: numToKeep = ${this.options.numToKeep}, existingFiles = ${existingFileDetails.length}`
+    );
+    debug("_clean: existing files are: ", existingFileDetails);
+    if (this._tooManyFiles(existingFileDetails.length)) {
+      const fileNamesToRemove = existingFileDetails
+        .map(f => path.format({ dir: this.fileObject.dir, base: f.filename }))
+        .slice(0, existingFileDetails.length - this.options.numToKeep - 1);
+      await deleteFiles(fileNamesToRemove);
+    }
+  }
+
+  _tooManyFiles(numFiles) {
+    return this.options.numToKeep > 0 && numFiles > this.options.numToKeep;
+  }
+}
+
 const moveAndMaybeCompressFile = async (
   sourceFilePath,
   targetFilePath,
@@ -58,252 +303,8 @@ const moveAndMaybeCompressFile = async (
 };
 
 const deleteFiles = fileNames => {
-  debug(`files to delete: ${fileNames}`);
+  debug(`deleteFiles: files to delete: ${fileNames}`);
   return Promise.all(fileNames.map(f => fs.unlink(f)));
 };
-
-/**
- * RollingFileWriteStream is mainly used when writing to a file rolling by date or size.
- * RollingFileWriteStream inherits from stream.Writable
- */
-class RollingFileWriteStream extends Writable {
-  /**
-   * Create a RollingFileWriteStream
-   * @constructor
-   * @param {string} filePath - The file path to write.
-   * @param {object} options - The extra options
-   * @param {number} options.numToKeep - The max numbers of files to keep.
-   * @param {number} options.maxSize - The maxSize one file can reach. Unit is Byte.
-   *                                   This should be more than 1024. The default is Number.MAX_SAFE_INTEGER.
-   * @param {string} options.mode - The mode of the files. The default is '0644'. Refer to stream.writable for more.
-   * @param {string} options.flags - The default is 'a'. Refer to stream.flags for more.
-   * @param {boolean} options.compress - Whether to compress backup files.
-   * @param {boolean} options.keepFileExt - Whether to keep the file extension.
-   * @param {string} options.pattern - The date string pattern in the file name.
-   * @param {boolean} options.alwaysIncludePattern - Whether to add date to the name of the first file.
-   */
-  constructor(filePath, options) {
-    debug(`creating RollingFileWriteStream. path=${filePath}`);
-    super(options);
-    this.options = this._parseOption(options);
-    this.fileObject = path.parse(filePath);
-    if (this.fileObject.dir === "") {
-      this.fileObject = path.parse(path.join(process.cwd(), filePath));
-    }
-    this.fileFormatter = fileNameFormatter({
-      file: this.fileObject,
-      alwaysIncludeDate: this.options.alwaysIncludePattern,
-      needsIndex: this.options.maxSize < Number.MAX_SAFE_INTEGER,
-      compress: this.options.compress,
-      keepFileExt: this.options.keepFileExt
-    });
-
-    this.fileNameParser = fileNameParser({
-      file: this.fileObject,
-      keepFileExt: this.options.keepFileExt,
-      pattern: this.options.pattern
-    });
-
-    this.state = {
-      currentSize: 0
-    };
-
-    if (this.options.pattern) {
-      this.state.currentDate = format(this.options.pattern, newNow());
-    }
-
-    this.filename = this.fileFormatter({
-      index: 0,
-      date: this.state.currentDate
-    });
-    if (["a", "a+", "as", "as+"].includes(this.options.flags)) {
-      this._setExistingSizeAndDate();
-    }
-
-    debug(
-      `create new file with no hot file. name=${
-        this.filename
-      }, state=${JSON.stringify(this.state)}`
-    );
-    this._renewWriteStream();
-  }
-
-  _setExistingSizeAndDate() {
-    try {
-      const stats = fs.statSync(this.filename);
-      this.state.currentSize = stats.size;
-      if (this.options.pattern) {
-        this.state.currentDate = format(this.options.pattern, stats.birthtime);
-      }
-    } catch (e) {
-      //file does not exist, that's fine - move along
-      return;
-    }
-  }
-
-  _parseOption(rawOptions) {
-    const defaultOptions = {
-      maxSize: Number.MAX_SAFE_INTEGER,
-      numToKeep: Number.MAX_SAFE_INTEGER,
-      encoding: "utf8",
-      mode: parseInt("0644", 8),
-      flags: "a",
-      compress: false,
-      keepFileExt: false,
-      alwaysIncludePattern: false
-    };
-    const options = Object.assign({}, defaultOptions, rawOptions);
-    if (options.maxSize <= 0) {
-      throw new Error(`options.maxSize (${options.maxSize}) should be > 0`);
-    }
-    if (options.numToKeep <= 0) {
-      throw new Error(`options.numToKeep (${options.numToKeep}) should be > 0`);
-    }
-    debug(`creating stream with option=${JSON.stringify(options)}`);
-    return options;
-  }
-
-  _dateChanged() {
-    return (
-      this.state.currentDate &&
-      this.state.currentDate !== format(this.options.pattern, newNow())
-    );
-  }
-
-  _tooBig() {
-    return this.state.currentSize >= this.options.maxSize;
-  }
-
-  async _shouldRoll() {
-    if (this._dateChanged() || this._tooBig()) {
-      debug(
-        `rolling because dateChanged? ${this._dateChanged()} or tooBig? ${this._tooBig()}`
-      );
-      await this._roll();
-    }
-  }
-
-  _write(chunk, encoding, callback) {
-    this._shouldRoll().then(() => {
-      debug(
-        `writing chunk. ` +
-          `file=${this.currentFileStream.path} ` +
-          `state=${JSON.stringify(this.state)} ` +
-          `chunk=${chunk}`
-      );
-      this.currentFileStream.write(chunk, encoding, e => {
-        this.state.currentSize += chunk.length;
-        callback(e);
-      });
-    });
-  }
-
-  // Sorted from the oldest to the latest
-  async _getExistingFiles() {
-    const files = await fs.readdir(this.fileObject.dir).catch(() => []);
-
-    debug(`_getExistingFiles: files=${files}`);
-    const existingFileDetails = files
-      .map(n => this.fileNameParser(n))
-      .filter(n => n);
-
-    const getKey = n =>
-      (n.timestamp ? n.timestamp : newNow().getTime()) - n.index;
-    existingFileDetails.sort((a, b) => getKey(a) - getKey(b));
-
-    return existingFileDetails;
-  }
-
-  async _moveOldFiles() {
-    const currentFilePath = this.currentFileStream.path;
-
-    const files = await this._getExistingFiles();
-    const todaysFiles = this.state.currentDate
-      ? files.filter(f => f.date === this.state.currentDate)
-      : files;
-    for (let i = todaysFiles.length; i >= 0; i--) {
-      debug(`i = ${i}`);
-      const sourceFilePath =
-        i === 0
-          ? currentFilePath
-          : this.fileFormatter({
-              date: this.state.currentDate,
-              index: i
-            });
-      const targetFilePath = this.fileFormatter({
-        date: this.state.currentDate,
-        index: i + 1
-      });
-
-      await moveAndMaybeCompressFile(
-        sourceFilePath,
-        targetFilePath,
-        this.options.compress && i === 0
-      );
-    }
-
-    this.state.currentSize = 0;
-    this.state.currentDate = this.state.currentDate
-      ? format(this.options.pattern, newNow())
-      : null;
-    debug(`finished rolling files. state=${JSON.stringify(this.state)}`);
-    this._renewWriteStream();
-    // wait for the file to be open before cleaning up old ones,
-    // otherwise the daysToKeep calculations can be off
-    await new Promise((resolve, reject) => {
-      this.currentFileStream.write("", "utf8", () => {
-        this._clean()
-          .then(resolve)
-          .catch(reject);
-      });
-    });
-  }
-
-  _roll() {
-    debug(`_roll: closing the current stream`);
-    return new Promise((resolve, reject) => {
-      this.currentFileStream.end("", this.options.encoding, () => {
-        this._moveOldFiles()
-          .then(resolve)
-          .catch(reject);
-      });
-    });
-  }
-
-  _renewWriteStream() {
-    fs.ensureDirSync(this.fileObject.dir);
-    const filePath = this.fileFormatter({
-      date: this.state.currentDate,
-      index: 0
-    });
-    const ops = {
-      flags: this.options.flags,
-      encoding: this.options.encoding,
-      mode: this.options.mode
-    };
-    this.currentFileStream = fs.createWriteStream(filePath, ops);
-    this.currentFileStream.on("error", e => {
-      this.emit("error", e);
-    });
-  }
-
-  _tooManyFiles(numFiles) {
-    return this.options.numToKeep > 0 && numFiles > this.options.numToKeep;
-  }
-
-  async _clean() {
-    const existingFileDetails = await this._getExistingFiles();
-    debug(
-      `numToKeep = ${this.options.numToKeep}, existingFiles = ${existingFileDetails.length}`
-    );
-    debug("existing files are: ", existingFileDetails);
-    if (this._tooManyFiles(existingFileDetails.length)) {
-      const fileNamesToRemove = existingFileDetails
-        .map(f => path.format({ dir: this.fileObject.dir, base: f.filename }))
-        .slice(0, existingFileDetails.length - this.options.numToKeep - 1);
-      await deleteFiles(fileNamesToRemove);
-    }
-  }
-}
 
 module.exports = RollingFileWriteStream;

--- a/test/DateRollingFileStream-test.js
+++ b/test/DateRollingFileStream-test.js
@@ -1,199 +1,213 @@
 /**
  * This file will be removed.
  */
-'use strict';
+"use strict";
 
-require('should');
+require("should");
 
-const fs = require('fs')
-  , zlib = require('zlib')
-  , proxyquire = require('proxyquire').noPreserveCache()
-  , util = require('util')
-  , async = require('async')
-  , streams = require('stream');
+const fs = require("fs"),
+  path = require("path"),
+  zlib = require("zlib"),
+  proxyquire = require("proxyquire").noPreserveCache(),
+  util = require("util"),
+  async = require("async"),
+  streams = require("stream");
 
 let fakeNow = new Date(2012, 8, 12, 10, 37, 11);
 const mockNow = () => fakeNow;
-const RollingFileWriteStream = proxyquire('../lib/RollingFileWriteStream', {
-  './now': mockNow
+const RollingFileWriteStream = proxyquire("../lib/RollingFileWriteStream", {
+  "./now": mockNow
 });
-const DateRollingFileStream = proxyquire('../lib/DateRollingFileStream', {
-  './RollingFileWriteStream': RollingFileWriteStream
+const DateRollingFileStream = proxyquire("../lib/DateRollingFileStream", {
+  "./RollingFileWriteStream": RollingFileWriteStream
 });
 
 function remove(filename, cb) {
-  fs.unlink(filename, function () {
+  fs.unlink(filename, function() {
     cb();
   });
 }
 
-describe('DateRollingFileStream', function () {
-  describe('arguments', function () {
+describe("DateRollingFileStream", function() {
+  describe("arguments", function() {
     var stream;
 
-    before(function (done) {
+    before(function(done) {
       stream = new DateRollingFileStream(
-        __dirname + '/test-date-rolling-file-stream-1',
-        'yyyy-MM-dd.hh'
+        path.join(__dirname, "test-date-rolling-file-stream-1"),
+        "yyyy-MM-dd.hh"
       );
       done();
     });
 
-    after(function (done) {
-      remove(__dirname + '/test-date-rolling-file-stream-1', done);
+    after(function(done) {
+      remove(path.join(__dirname, "test-date-rolling-file-stream-1"), done);
     });
 
-    it('should take a filename and a pattern and return a WritableStream', function (done) {
-      stream.filename.should.eql(__dirname + '/test-date-rolling-file-stream-1');
-      stream.options.pattern.should.eql('yyyy-MM-dd.hh');
+    it("should take a filename and a pattern and return a WritableStream", function(done) {
+      stream.filename.should.eql(
+        path.join(__dirname, "test-date-rolling-file-stream-1")
+      );
+      stream.options.pattern.should.eql("yyyy-MM-dd.hh");
       stream.should.be.instanceOf(streams.Writable);
       done();
     });
 
-    it('with default settings for the underlying stream', function (done) {
+    it("with default settings for the underlying stream", function(done) {
       stream.currentFileStream.mode.should.eql(420);
-      stream.currentFileStream.flags.should.eql('a');
+      stream.currentFileStream.flags.should.eql("a");
       done();
     });
   });
 
-  describe('default arguments', function () {
+  describe("default arguments", function() {
     var stream;
 
-    before(function (done) {
-      stream = new DateRollingFileStream(__dirname + '/test-date-rolling-file-stream-2');
-      done();
-    });
-
-    after(function (done) {
-      remove(__dirname + '/test-date-rolling-file-stream-2', done);
-    });
-
-    it('should have pattern of .yyyy-MM-dd', function (done) {
-      stream.options.pattern.should.eql('yyyy-MM-dd');
-      done();
-    });
-  });
-
-  describe('with stream arguments', function () {
-    var stream;
-
-    before(function (done) {
+    before(function(done) {
       stream = new DateRollingFileStream(
-        __dirname + '/test-date-rolling-file-stream-3',
-        'yyyy-MM-dd',
-        {mode: parseInt('0666', 8)}
+        path.join(__dirname, "test-date-rolling-file-stream-2")
       );
       done();
     });
 
-    after(function (done) {
-      remove(__dirname + '/test-date-rolling-file-stream-3', done);
+    after(function(done) {
+      remove(path.join(__dirname, "test-date-rolling-file-stream-2"), done);
     });
 
-    it('should pass them to the underlying stream', function (done) {
-      stream.theStream.mode.should.eql(parseInt('0666', 8));
+    it("should have pattern of .yyyy-MM-dd", function(done) {
+      stream.options.pattern.should.eql("yyyy-MM-dd");
       done();
     });
   });
 
-  describe('with stream arguments but no pattern', function () {
+  describe("with stream arguments", function() {
     var stream;
 
-    before(function (done) {
+    before(function(done) {
       stream = new DateRollingFileStream(
-        __dirname + '/test-date-rolling-file-stream-4',
-        {mode: parseInt('0666', 8)}
+        path.join(__dirname, "test-date-rolling-file-stream-3"),
+        "yyyy-MM-dd",
+        { mode: parseInt("0666", 8) }
       );
       done();
     });
 
-    after(function (done) {
-      remove(__dirname + '/test-date-rolling-file-stream-4', done);
+    after(function(done) {
+      remove(path.join(__dirname, "test-date-rolling-file-stream-3"), done);
     });
 
-    it('should pass them to the underlying stream', function (done) {
-      stream.theStream.mode.should.eql(parseInt('0666', 8));
-      done();
-    });
-
-    it('should use default pattern', function (done) {
-      stream.options.pattern.should.eql('yyyy-MM-dd');
+    it("should pass them to the underlying stream", function(done) {
+      stream.theStream.mode.should.eql(parseInt("0666", 8));
       done();
     });
   });
 
-  describe('with a pattern of .yyyy-MM-dd', function () {
+  describe("with stream arguments but no pattern", function() {
     var stream;
 
-    before(function (done) {
+    before(function(done) {
       stream = new DateRollingFileStream(
-        __dirname + '/test-date-rolling-file-stream-5', '.yyyy-MM-dd',
+        path.join(__dirname, "test-date-rolling-file-stream-4"),
+        { mode: parseInt("0666", 8) }
+      );
+      done();
+    });
+
+    after(function(done) {
+      remove(path.join(__dirname, "test-date-rolling-file-stream-4"), done);
+    });
+
+    it("should pass them to the underlying stream", function(done) {
+      stream.theStream.mode.should.eql(parseInt("0666", 8));
+      done();
+    });
+
+    it("should use default pattern", function(done) {
+      stream.options.pattern.should.eql("yyyy-MM-dd");
+      done();
+    });
+  });
+
+  describe("with a pattern of .yyyy-MM-dd", function() {
+    var stream;
+
+    before(function(done) {
+      stream = new DateRollingFileStream(
+        path.join(__dirname, "test-date-rolling-file-stream-5"),
+        ".yyyy-MM-dd",
         null
       );
-      stream.write('First message\n', 'utf8', done);
+      stream.write("First message\n", "utf8", done);
     });
 
-    after(function (done) {
-      remove(__dirname + '/test-date-rolling-file-stream-5', done);
+    after(function(done) {
+      remove(path.join(__dirname, "test-date-rolling-file-stream-5"), done);
     });
 
-    it('should create a file with the base name', function (done) {
-      fs.readFile(__dirname + '/test-date-rolling-file-stream-5', 'utf8', function (err, contents) {
-        contents.should.eql('First message\n');
-        done(err);
-      });
+    it("should create a file with the base name", function(done) {
+      fs.readFile(
+        path.join(__dirname, "test-date-rolling-file-stream-5"),
+        "utf8",
+        function(err, contents) {
+          contents.should.eql("First message\n");
+          done(err);
+        }
+      );
     });
 
-    describe('when the day changes', function () {
-
-      before(function (done) {
+    describe("when the day changes", function() {
+      before(function(done) {
         fakeNow = new Date(2012, 8, 13, 0, 10, 12);
-        stream.write('Second message\n', 'utf8', done);
+        stream.write("Second message\n", "utf8", done);
       });
 
-      after(function (done) {
-        remove(__dirname + '/test-date-rolling-file-stream-5.2012-09-12', done);
+      after(function(done) {
+        remove(
+          path.join(__dirname, "test-date-rolling-file-stream-5.2012-09-12"),
+          done
+        );
       });
 
-      describe('the number of files', function () {
+      describe("the number of files", function() {
         var files = [];
 
-        before(function (done) {
-          fs.readdir(__dirname, function (err, list) {
+        before(function(done) {
+          fs.readdir(__dirname, function(err, list) {
             files = list;
             done(err);
           });
         });
 
-        it('should be two', function (done) {
-          files.filter(
-            function (file) {
-              return file.indexOf('test-date-rolling-file-stream-5') > -1;
-            }
-          ).should.have.length(2);
+        it("should be two", function(done) {
+          files
+            .filter(function(file) {
+              return file.indexOf("test-date-rolling-file-stream-5") > -1;
+            })
+            .should.have.length(2);
           done();
         });
       });
 
-      describe('the file without a date', function () {
-        it('should contain the second message', function (done) {
+      describe("the file without a date", function() {
+        it("should contain the second message", function(done) {
           fs.readFile(
-            __dirname + '/test-date-rolling-file-stream-5', 'utf8',
-            function (err, contents) {
-              contents.should.eql('Second message\n');
+            path.join(__dirname, "test-date-rolling-file-stream-5"),
+            "utf8",
+            function(err, contents) {
+              contents.should.eql("Second message\n");
               done(err);
             }
           );
         });
       });
 
-      describe('the file with the date', function () {
-        it('should contain the first message', function (done) {
+      describe("the file with the date", function() {
+        it("should contain the first message", function(done) {
           fs.readFile(
-            __dirname + '/test-date-rolling-file-stream-5.2012-09-12', 'utf8',
-            function (err, contents) {
-              contents.should.eql('First message\n');
+            path.join(__dirname, "test-date-rolling-file-stream-5.2012-09-12"),
+            "utf8",
+            function(err, contents) {
+              contents.should.eql("First message\n");
               done(err);
             }
           );
@@ -202,81 +216,110 @@ describe('DateRollingFileStream', function () {
     });
   });
 
-  describe('with alwaysIncludePattern', function () {
+  describe("with alwaysIncludePattern", function() {
     var stream;
 
-    before(function (done) {
+    before(function(done) {
       fakeNow = new Date(2012, 8, 12, 11, 10, 12);
       remove(
-        __dirname + '/test-date-rolling-file-stream-pattern.2012-09-12-11.log',
-        function () {
+        path.join(
+          __dirname,
+          "test-date-rolling-file-stream-pattern.2012-09-12-11.log"
+        ),
+        function() {
           stream = new DateRollingFileStream(
-            __dirname + '/test-date-rolling-file-stream-pattern',
-            '.yyyy-MM-dd-hh.log',
-            {alwaysIncludePattern: true}
+            path.join(__dirname, "test-date-rolling-file-stream-pattern"),
+            ".yyyy-MM-dd-hh.log",
+            { alwaysIncludePattern: true }
           );
-          setTimeout(function () {
-            stream.write('First message\n', 'utf8', done);
+          setTimeout(function() {
+            stream.write("First message\n", "utf8", done);
           }, 50);
         }
       );
     });
 
-    after(function (done) {
-      remove(__dirname + '/test-date-rolling-file-stream-pattern.2012-09-12-11.log', done);
+    after(function(done) {
+      remove(
+        path.join(
+          __dirname,
+          "test-date-rolling-file-stream-pattern.2012-09-12-11.log"
+        ),
+        done
+      );
     });
 
-    it('should create a file with the pattern set', function (done) {
+    it("should create a file with the pattern set", function(done) {
       fs.readFile(
-        __dirname + '/test-date-rolling-file-stream-pattern.2012-09-12-11.log', 'utf8',
-        function (err, contents) {
-          contents.should.eql('First message\n');
+        path.join(
+          __dirname,
+          "test-date-rolling-file-stream-pattern.2012-09-12-11.log"
+        ),
+        "utf8",
+        function(err, contents) {
+          contents.should.eql("First message\n");
           done(err);
         }
       );
     });
 
-    describe('when the day changes', function () {
-      before(function (done) {
+    describe("when the day changes", function() {
+      before(function(done) {
         fakeNow = new Date(2012, 8, 12, 12, 10, 12);
-        stream.write('Second message\n', 'utf8', done);
+        stream.write("Second message\n", "utf8", done);
       });
 
-      after(function (done) {
-        remove(__dirname + '/test-date-rolling-file-stream-pattern.2012-09-12-12.log', done);
+      after(function(done) {
+        remove(
+          path.join(
+            __dirname,
+            "test-date-rolling-file-stream-pattern.2012-09-12-12.log"
+          ),
+          done
+        );
       });
 
-      describe('the number of files', function () {
-        it('should be two', function (done) {
-          fs.readdir(__dirname, function (err, files) {
-            files.filter(
-              function (file) {
-                return file.indexOf('test-date-rolling-file-stream-pattern') > -1;
-              }
-            ).should.have.length(2);
+      describe("the number of files", function() {
+        it("should be two", function(done) {
+          fs.readdir(__dirname, function(err, files) {
+            files
+              .filter(function(file) {
+                return (
+                  file.indexOf("test-date-rolling-file-stream-pattern") > -1
+                );
+              })
+              .should.have.length(2);
             done(err);
           });
         });
       });
 
-      describe('the file with the later date', function () {
-        it('should contain the second message', function (done) {
+      describe("the file with the later date", function() {
+        it("should contain the second message", function(done) {
           fs.readFile(
-            __dirname + '/test-date-rolling-file-stream-pattern.2012-09-12-12.log', 'utf8',
-            function (err, contents) {
-              contents.should.eql('Second message\n');
+            path.join(
+              __dirname,
+              "test-date-rolling-file-stream-pattern.2012-09-12-12.log"
+            ),
+            "utf8",
+            function(err, contents) {
+              contents.should.eql("Second message\n");
               done(err);
             }
           );
         });
       });
 
-      describe('the file with the date', function () {
-        it('should contain the first message', function (done) {
+      describe("the file with the date", function() {
+        it("should contain the first message", function(done) {
           fs.readFile(
-            __dirname + '/test-date-rolling-file-stream-pattern.2012-09-12-11.log', 'utf8',
-            function (err, contents) {
-              contents.should.eql('First message\n');
+            path.join(
+              __dirname,
+              "test-date-rolling-file-stream-pattern.2012-09-12-11.log"
+            ),
+            "utf8",
+            function(err, contents) {
+              contents.should.eql("First message\n");
               done(err);
             }
           );
@@ -285,89 +328,92 @@ describe('DateRollingFileStream', function () {
     });
   });
 
-  describe('with a pattern that evaluates to digits', function() {
+  describe("with a pattern that evaluates to digits", function() {
     let stream;
     before(done => {
       fakeNow = new Date(2012, 8, 12, 0, 10, 12);
       stream = new DateRollingFileStream(
-        __dirname + '/digits.log',
-        '.yyyyMMdd'
+        path.join(__dirname, "digits.log"),
+        ".yyyyMMdd"
       );
-      stream.write('First message\n', 'utf8', done);
+      stream.write("First message\n", "utf8", done);
     });
 
-    describe('when the day changes', function () {
-      before(function (done) {
+    describe("when the day changes", function() {
+      before(function(done) {
         fakeNow = new Date(2012, 8, 13, 0, 10, 12);
-        stream.write('Second message\n', 'utf8', done);
+        stream.write("Second message\n", "utf8", done);
       });
 
-      it('should be two files (it should not get confused by indexes)', function (done) {
-        fs.readdir(__dirname, function (err, files) {
-          var logFiles = files.filter(
-            function (file) {
-              return file.indexOf('digits.log') > -1;
-            }
-          );
+      it("should be two files (it should not get confused by indexes)", function(done) {
+        fs.readdir(__dirname, function(err, files) {
+          var logFiles = files.filter(function(file) {
+            return file.indexOf("digits.log") > -1;
+          });
           logFiles.should.have.length(2);
 
-          fs.readFile(__dirname + '/digits.log.20120912', 'utf8',
+          fs.readFile(
+            path.join(__dirname, "digits.log.20120912"),
+            "utf8",
             (err, contents) => {
-              contents.should.eql('First message\n');
-              fs.readFile(__dirname + '/digits.log', 'utf8', (e, c) => {
-                c.should.eql('Second message\n');
-                done(err || e);
-              });
+              contents.should.eql("First message\n");
+              fs.readFile(
+                path.join(__dirname, "digits.log"),
+                "utf8",
+                (e, c) => {
+                  c.should.eql("Second message\n");
+                  done(err || e);
+                }
+              );
             }
           );
         });
       });
     });
 
-    after(function (done) {
-      remove(
-        __dirname + '/digits.log',
-        function () {
-          remove(__dirname + '/digits.log.20120912', done);
-        }
-      );
+    after(function(done) {
+      remove(path.join(__dirname, "digits.log"), function() {
+        remove(path.join(__dirname, "digits.log.20120912"), done);
+      });
     });
-
   });
 
-  describe('with compress option', function () {
+  describe("with compress option", function() {
     var stream;
 
-    before(function (done) {
+    before(function(done) {
       fakeNow = new Date(2012, 8, 12, 0, 10, 12);
       stream = new DateRollingFileStream(
-        __dirname + '/compressed.log',
-        '.yyyy-MM-dd',
-        {compress: true}
+        path.join(__dirname, "compressed.log"),
+        ".yyyy-MM-dd",
+        { compress: true }
       );
-      stream.write('First message\n', 'utf8', done);
+      stream.write("First message\n", "utf8", done);
     });
 
-    describe('when the day changes', function () {
-      before(function (done) {
+    describe("when the day changes", function() {
+      before(function(done) {
         fakeNow = new Date(2012, 8, 13, 0, 10, 12);
-        stream.write('Second message\n', 'utf8', done);
+        stream.write("Second message\n", "utf8", done);
       });
 
-      it('should be two files, one compressed', function (done) {
-        fs.readdir(__dirname, function (err, files) {
-          var logFiles = files.filter(
-            function (file) {
-              return file.indexOf('compressed.log') > -1;
-            }
-          );
+      it("should be two files, one compressed", function(done) {
+        fs.readdir(__dirname, function(err, files) {
+          var logFiles = files.filter(function(file) {
+            return file.indexOf("compressed.log") > -1;
+          });
           logFiles.should.have.length(2);
 
           zlib.gunzip(
-            fs.readFileSync(__dirname + '/compressed.log.2012-09-12.gz'),
-            function (err, contents) {
-              contents.toString('utf8').should.eql('First message\n');
-              fs.readFileSync(__dirname + '/compressed.log', 'utf8').should.eql('Second message\n');
+            fs.readFileSync(
+              path.join(__dirname, "compressed.log.2012-09-12.gz")
+            ),
+            function(err, contents) {
+              contents.toString("utf8").should.eql("First message\n");
+              fs.readFileSync(
+                path.join(__dirname, "compressed.log"),
+                "utf8"
+              ).should.eql("Second message\n");
               done(err);
             }
           );
@@ -375,98 +421,94 @@ describe('DateRollingFileStream', function () {
       });
     });
 
-    after(function (done) {
-      remove(
-        __dirname + '/compressed.log',
-        function () {
-          remove(__dirname + '/compressed.log.2012-09-12.gz', done);
-        }
-      );
+    after(function(done) {
+      remove(path.join(__dirname, "compressed.log"), function() {
+        remove(path.join(__dirname, "compressed.log.2012-09-12.gz"), done);
+      });
     });
-
   });
 
-  describe('with keepFileExt option', function () {
+  describe("with keepFileExt option", function() {
     var stream;
 
-    before(function (done) {
+    before(function(done) {
       fakeNow = new Date(2012, 8, 12, 0, 10, 12);
       stream = new DateRollingFileStream(
-        __dirname + '/keepFileExt.log',
-        '.yyyy-MM-dd',
-        {keepFileExt: true}
+        path.join(__dirname, "keepFileExt.log"),
+        ".yyyy-MM-dd",
+        { keepFileExt: true }
       );
-      stream.write('First message\n', 'utf8', done);
+      stream.write("First message\n", "utf8", done);
     });
 
-    describe('when the day changes', function () {
-      before(function (done) {
+    describe("when the day changes", function() {
+      before(function(done) {
         fakeNow = new Date(2012, 8, 13, 0, 10, 12);
-        stream.write('Second message\n', 'utf8', done);
+        stream.write("Second message\n", "utf8", done);
       });
 
-      it('should be two files', function (done) {
-        fs.readdir(__dirname, function (err, files) {
-          var logFiles = files.filter(
-            function (file) {
-              return file.indexOf('keepFileExt') > -1;
-            }
-          );
+      it("should be two files", function(done) {
+        fs.readdir(__dirname, function(err, files) {
+          var logFiles = files.filter(function(file) {
+            return file.indexOf("keepFileExt") > -1;
+          });
           logFiles.should.have.length(2);
-          fs.readFileSync(__dirname + '/keepFileExt.2012-09-12.log', 'utf8')
-            .should.eql('First message\n');
-          fs.readFileSync(__dirname + '/keepFileExt.log', 'utf8')
-            .should.eql('Second message\n');
+          fs.readFileSync(
+            path.join(__dirname, "keepFileExt.2012-09-12.log"),
+            "utf8"
+          ).should.eql("First message\n");
+          fs.readFileSync(
+            path.join(__dirname, "keepFileExt.log"),
+            "utf8"
+          ).should.eql("Second message\n");
           done(err);
         });
       });
     });
 
-    after(function (done) {
-      remove(
-        __dirname + '/keepFileExt.log',
-        function () {
-          remove(__dirname + '/keepFileExt.2012-09-12.log', done);
-        }
-      );
+    after(function(done) {
+      remove(path.join(__dirname, "keepFileExt.log"), function() {
+        remove(path.join(__dirname, "keepFileExt.2012-09-12.log"), done);
+      });
     });
-
   });
 
-  describe('with compress option and keepFileExt option', function () {
+  describe("with compress option and keepFileExt option", function() {
     var stream;
 
-    before(function (done) {
+    before(function(done) {
       fakeNow = new Date(2012, 8, 12, 0, 10, 12);
       stream = new DateRollingFileStream(
-        __dirname + '/compressedAndKeepExt.log',
-        '.yyyy-MM-dd',
-        {compress: true, keepFileExt: true}
+        path.join(__dirname, "compressedAndKeepExt.log"),
+        ".yyyy-MM-dd",
+        { compress: true, keepFileExt: true }
       );
-      stream.write('First message\n', 'utf8', done);
+      stream.write("First message\n", "utf8", done);
     });
 
-    describe('when the day changes', function () {
-      before(function (done) {
+    describe("when the day changes", function() {
+      before(function(done) {
         fakeNow = new Date(2012, 8, 13, 0, 10, 12);
-        stream.write('Second message\n', 'utf8', done);
+        stream.write("Second message\n", "utf8", done);
       });
 
-      it('should be two files, one compressed', function (done) {
-        fs.readdir(__dirname, function (err, files) {
-          var logFiles = files.filter(
-            function (file) {
-              return file.indexOf('compressedAndKeepExt') > -1;
-            }
-          );
+      it("should be two files, one compressed", function(done) {
+        fs.readdir(__dirname, function(err, files) {
+          var logFiles = files.filter(function(file) {
+            return file.indexOf("compressedAndKeepExt") > -1;
+          });
           logFiles.should.have.length(2);
 
           zlib.gunzip(
-            fs.readFileSync(__dirname + '/compressedAndKeepExt.2012-09-12.log.gz'),
-            function (err, contents) {
-              contents.toString('utf8').should.eql('First message\n');
-              fs.readFileSync(__dirname + '/compressedAndKeepExt.log', 'utf8')
-                .should.eql('Second message\n');
+            fs.readFileSync(
+              path.join(__dirname, "compressedAndKeepExt.2012-09-12.log.gz")
+            ),
+            function(err, contents) {
+              contents.toString("utf8").should.eql("First message\n");
+              fs.readFileSync(
+                path.join(__dirname, "compressedAndKeepExt.log"),
+                "utf8"
+              ).should.eql("Second message\n");
               done(err);
             }
           );
@@ -474,139 +516,156 @@ describe('DateRollingFileStream', function () {
       });
     });
 
-    after(function (done) {
-      remove(
-        __dirname + '/compressedAndKeepExt.log',
-        function () {
-          remove(__dirname + '/compressedAndKeepExt.2012-09-12.log.gz', done);
-        }
-      );
+    after(function(done) {
+      remove(path.join(__dirname, "compressedAndKeepExt.log"), function() {
+        remove(
+          path.join(__dirname, "compressedAndKeepExt.2012-09-12.log.gz"),
+          done
+        );
+      });
     });
-
   });
 
-  describe('with daysToKeep option', function () {
+  describe("with daysToKeep option", function() {
     var stream;
     var daysToKeep = 4;
     var numOriginalLogs = 10;
 
-    before(function (done) {
+    before(function(done) {
       var day = 0;
       var streams = [];
       async.whilst(
-        function () {
+        function() {
           return day < numOriginalLogs;
         },
-        function (nextCallback) {
+        function(nextCallback) {
           fakeNow = new Date(2012, 8, 20 - day, 0, 10, 12);
           var currentStream = new DateRollingFileStream(
-            __dirname + '/daysToKeep.log',
-            '.yyyy-MM-dd',
+            path.join(__dirname, "daysToKeep.log"),
+            ".yyyy-MM-dd",
             {
               alwaysIncludePattern: true,
               daysToKeep: daysToKeep
             }
           );
-          async.waterfall([
-            function (callback) {
-              currentStream.write(util.format('Message on day %d\n', day), 'utf8', callback);
-            },
-            function (callback) {
-              fs.utimes(currentStream.filename, fakeNow, fakeNow, callback);
-            }
-          ],
-          function (err) {
-            day++;
-            streams.push(currentStream);
-            nextCallback(err);
-          });
-        },
-        function (err) {
-          stream = streams[0];
-          done(err);
-        });
-      });
-
-      describe('when the day changes', function () {
-        before(function (done) {
-          fakeNow = new Date(2012, 8, 21, 0, 10, 12);
-          stream.write('Second message\n', 'utf8', done);
-        });
-
-        it('should be daysToKeep + 1 files left from numOriginalLogs', function (done) {
-          fs.readdir(__dirname, function (err, files) {
-            var logFiles = files.filter(
-              function (file) {
-                return file.indexOf('daysToKeep.log') > -1;
+          async.waterfall(
+            [
+              function(callback) {
+                currentStream.write(
+                  util.format("Message on day %d\n", day),
+                  "utf8",
+                  callback
+                );
+              },
+              function(callback) {
+                fs.utimes(currentStream.filename, fakeNow, fakeNow, callback);
               }
-            );
-            logFiles.should.have.length(daysToKeep + 1);
-            done(err);
-          });
-        });
-      });
-
-      after(function (done) {
-        fs.readdir(__dirname, function (err, files) {
-          var logFiles = files.filter(
-            function (file) {
-              return file.indexOf('daysToKeep.log') > -1;
+            ],
+            function(err) {
+              day++;
+              streams.push(currentStream);
+              nextCallback(err);
             }
           );
-          async.each(logFiles, (logFile, nextCallback) => {
-            remove(__dirname + '/' + logFile, nextCallback);
-          }, done);
+        },
+        function(err) {
+          stream = streams[0];
+          done(err);
+        }
+      );
+    });
+
+    describe("when the day changes", function() {
+      before(function(done) {
+        fakeNow = new Date(2012, 8, 21, 0, 10, 12);
+        stream.write("Second message\n", "utf8", done);
+      });
+
+      it("should be daysToKeep + 1 files left from numOriginalLogs", function(done) {
+        fs.readdir(__dirname, function(err, files) {
+          var logFiles = files.filter(function(file) {
+            return file.indexOf("daysToKeep.log") > -1;
+          });
+          logFiles.should.have.length(daysToKeep + 1);
+          done(err);
         });
       });
     });
 
-  describe('with daysToKeep and compress options', function () {
+    after(function(done) {
+      fs.readdir(__dirname, function(err, files) {
+        var logFiles = files.filter(function(file) {
+          return file.indexOf("daysToKeep.log") > -1;
+        });
+        async.each(
+          logFiles,
+          (logFile, nextCallback) => {
+            remove(path.join(__dirname, logFile), nextCallback);
+          },
+          done
+        );
+      });
+    });
+  });
+
+  describe("with daysToKeep and compress options", function() {
     var stream;
     var daysToKeep = 4;
     var numOriginalLogs = 10;
 
-    before(function (done) {
+    before(function(done) {
       var day = 0;
       var streams = [];
       async.whilst(
-        function () {
+        function() {
           return day < numOriginalLogs;
         },
-        function (nextCallback) {
+        function(nextCallback) {
           fakeNow = new Date(2012, 8, 20 - day, 0, 10, 12);
           var currentStream = new DateRollingFileStream(
-            __dirname + '/compressedDaysToKeep.log',
-            '.yyyy-MM-dd',
+            path.join(__dirname, "compressedDaysToKeep.log"),
+            ".yyyy-MM-dd",
             {
               alwaysIncludePattern: true,
               compress: true,
               daysToKeep: daysToKeep
             }
           );
-          async.waterfall([
-            function (callback) {
-              currentStream.write(util.format('Message on day %d\n', day), 'utf8', callback);
-            },
-            function (callback) {
-              var filename = currentStream.filename;
-              var gzip = zlib.createGzip();
-              var inp = fs.createReadStream(filename);
-              var out = fs.createWriteStream(filename+'.gz');
-              inp.pipe(gzip).pipe(out);
+          async.waterfall(
+            [
+              function(callback) {
+                currentStream.write(
+                  util.format("Message on day %d\n", day),
+                  "utf8",
+                  callback
+                );
+              },
+              function(callback) {
+                var filename = currentStream.filename;
+                var gzip = zlib.createGzip();
+                var inp = fs.createReadStream(filename);
+                var out = fs.createWriteStream(filename + ".gz");
+                inp.pipe(gzip).pipe(out);
 
-              out.on('finish', function () {
-                fs.unlink(filename, callback);
-              });
-            },
-            function (callback) {
-              fs.utimes(currentStream.filename + '.gz', fakeNow, fakeNow, callback);
+                out.on("finish", function() {
+                  fs.unlink(filename, callback);
+                });
+              },
+              function(callback) {
+                fs.utimes(
+                  currentStream.filename + ".gz",
+                  fakeNow,
+                  fakeNow,
+                  callback
+                );
+              }
+            ],
+            function(err) {
+              day++;
+              streams.push(currentStream);
+              nextCallback(err);
             }
-          ],
-          function (err) {
-            day++;
-            streams.push(currentStream);
-            nextCallback(err);
-          });
+          );
         },
         () => {
           stream = streams[0];
@@ -615,38 +674,37 @@ describe('DateRollingFileStream', function () {
       );
     });
 
-    describe('when the day changes', function () {
-      before(function (done) {
+    describe("when the day changes", function() {
+      before(function(done) {
         fakeNow = new Date(2012, 8, 21, 0, 10, 12);
-        stream.write('New file message\n', 'utf8', done);
+        stream.write("New file message\n", "utf8", done);
       });
 
-      it('should be 4 files left from original 3', function (done) {
-        fs.readdir(__dirname, function (err, files) {
-          var logFiles = files.filter(
-            function (file) {
-              return file.indexOf('compressedDaysToKeep.log') > -1;
-            }
-          );
+      it("should be 4 files left from original 3", function(done) {
+        fs.readdir(__dirname, function(err, files) {
+          var logFiles = files.filter(function(file) {
+            return file.indexOf("compressedDaysToKeep.log") > -1;
+          });
           logFiles.should.have.length(daysToKeep + 1);
           done(err);
         });
       });
     });
 
-    after(function (done) {
-      fs.readdir(__dirname, function (err, files) {
-        var logFiles = files.filter(
-          function (file) {
-            return file.indexOf('compressedDaysToKeep.log') > -1;
+    after(function(done) {
+      fs.readdir(__dirname, function(err, files) {
+        var logFiles = files.filter(function(file) {
+          return file.indexOf("compressedDaysToKeep.log") > -1;
+        });
+        async.each(
+          logFiles,
+          function(logFile, nextCallback) {
+            remove(path.join(__dirname, logFile), nextCallback);
+          },
+          function(err) {
+            done(err);
           }
         );
-        async.each(logFiles, function (logFile, nextCallback) {
-          remove(__dirname + '/' + logFile, nextCallback);
-        },
-        function (err) {
-          done(err);
-        });
       });
     });
   });

--- a/test/RollingFileStream-test.js
+++ b/test/RollingFileStream-test.js
@@ -24,9 +24,9 @@ describe("RollingFileStream", function() {
     var stream;
 
     before(function(done) {
-      remove(__dirname + "/test-rolling-file-stream", function() {
+      remove(path.join(__dirname, "test-rolling-file-stream"), function() {
         stream = new RollingFileStream(
-          __dirname + "/test-rolling-file-stream",
+          path.join(__dirname, "test-rolling-file-stream"),
           1024,
           5
         );
@@ -35,12 +35,14 @@ describe("RollingFileStream", function() {
     });
 
     after(function(done) {
-      remove(__dirname + "/test-rolling-file-stream", done);
+      remove(path.join(__dirname, "test-rolling-file-stream"), done);
     });
 
     it("should take a filename, file size (bytes), no. backups, return Writable", function() {
       stream.should.be.an.instanceOf(streams.Writable);
-      stream.filename.should.eql(__dirname + "/test-rolling-file-stream");
+      stream.filename.should.eql(
+        path.join(__dirname, "test-rolling-file-stream")
+      );
       stream.size.should.eql(1024);
       stream.backups.should.eql(5);
     });
@@ -54,7 +56,7 @@ describe("RollingFileStream", function() {
   describe("with stream arguments", function() {
     it("should pass them to the underlying stream", function() {
       var stream = new RollingFileStream(
-        __dirname + "/test-rolling-file-stream",
+        path.join(__dirname, "test-rolling-file-stream"),
         1024,
         5,
         { mode: parseInt("0666", 8) }
@@ -63,57 +65,60 @@ describe("RollingFileStream", function() {
     });
 
     after(function(done) {
-      remove(__dirname + "/test-rolling-file-stream", done);
+      remove(path.join(__dirname, "test-rolling-file-stream"), done);
     });
   });
 
   describe("without size", function() {
     it("should default to max int size", function() {
       var stream = new RollingFileStream(
-        __dirname + "/test-rolling-file-stream"
+        path.join(__dirname, "test-rolling-file-stream")
       );
       stream.size.should.eql(Number.MAX_SAFE_INTEGER);
     });
 
     after(function(done) {
-      remove(__dirname + "/test-rolling-file-stream", done);
+      remove(path.join(__dirname, "test-rolling-file-stream"), done);
     });
   });
 
   describe("without number of backups", function() {
     it("should default to 1 backup", function() {
       var stream = new RollingFileStream(
-        __dirname + "/test-rolling-file-stream",
+        path.join(__dirname, "test-rolling-file-stream"),
         1024
       );
       stream.backups.should.eql(1);
     });
 
     after(function(done) {
-      remove(__dirname + "/test-rolling-file-stream", done);
+      remove(path.join(__dirname, "test-rolling-file-stream"), done);
     });
   });
 
   describe("writing less than the file size", function() {
     before(function(done) {
-      remove(__dirname + "/test-rolling-file-stream-write-less", function() {
-        var stream = new RollingFileStream(
-          __dirname + "/test-rolling-file-stream-write-less",
-          100
-        );
-        stream.write("cheese", "utf8", function() {
-          stream.end(done);
-        });
-      });
+      remove(
+        path.join(__dirname, "test-rolling-file-stream-write-less"),
+        function() {
+          var stream = new RollingFileStream(
+            path.join(__dirname, "test-rolling-file-stream-write-less"),
+            100
+          );
+          stream.write("cheese", "utf8", function() {
+            stream.end(done);
+          });
+        }
+      );
     });
 
     after(function(done) {
-      remove(__dirname + "/test-rolling-file-stream-write-less", done);
+      remove(path.join(__dirname, "test-rolling-file-stream-write-less"), done);
     });
 
     it("should write to the file", function(done) {
       fs.readFile(
-        __dirname + "/test-rolling-file-stream-write-less",
+        path.join(__dirname, "test-rolling-file-stream-write-less"),
         "utf8",
         function(err, contents) {
           contents.should.eql("cheese");
@@ -138,13 +143,13 @@ describe("RollingFileStream", function() {
     before(function(done) {
       async.forEach(
         [
-          __dirname + "/test-rolling-file-stream-write-more",
-          __dirname + "/test-rolling-file-stream-write-more.1"
+          path.join(__dirname, "test-rolling-file-stream-write-more"),
+          path.join(__dirname, "/test-rolling-file-stream-write-more.1")
         ],
         remove,
         function() {
           var stream = new RollingFileStream(
-            __dirname + "/test-rolling-file-stream-write-more",
+            path.join(__dirname, "test-rolling-file-stream-write-more"),
             45
           );
           async.forEachSeries(
@@ -163,8 +168,8 @@ describe("RollingFileStream", function() {
     after(function(done) {
       async.forEach(
         [
-          __dirname + "/test-rolling-file-stream-write-more",
-          __dirname + "/test-rolling-file-stream-write-more.1"
+          path.join(__dirname, "test-rolling-file-stream-write-more"),
+          path.join(__dirname, "test-rolling-file-stream-write-more.1")
         ],
         remove,
         done
@@ -184,7 +189,7 @@ describe("RollingFileStream", function() {
 
     it("should write the last two log messages to the first file", function(done) {
       fs.readFile(
-        __dirname + "/test-rolling-file-stream-write-more",
+        path.join(__dirname, "test-rolling-file-stream-write-more"),
         "utf8",
         function(err, contents) {
           contents.should.eql("5.cheese\n6.cheese\n");
@@ -195,7 +200,7 @@ describe("RollingFileStream", function() {
 
     it("should write the first five log messages to the second file", function(done) {
       fs.readFile(
-        __dirname + "/test-rolling-file-stream-write-more.1",
+        path.join(__dirname, "test-rolling-file-stream-write-more.1"),
         "utf8",
         function(err, contents) {
           contents.should.eql(
@@ -448,11 +453,11 @@ describe("RollingFileStream", function() {
     before(function(done) {
       async.forEach(
         [
-          __dirname + "/test-rolling-stream-with-existing-files.11",
-          __dirname + "/test-rolling-stream-with-existing-files.20",
-          __dirname + "/test-rolling-stream-with-existing-files.-1",
-          __dirname + "/test-rolling-stream-with-existing-files.1.1",
-          __dirname + "/test-rolling-stream-with-existing-files.1"
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.11"),
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.20"),
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.-1"),
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.1.1"),
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.1")
         ],
         remove,
         function(err) {
@@ -460,18 +465,33 @@ describe("RollingFileStream", function() {
 
           async.forEach(
             [
-              __dirname + "/test-rolling-stream-with-existing-files.11",
-              __dirname + "/test-rolling-stream-with-existing-files.20",
-              __dirname + "/test-rolling-stream-with-existing-files.-1",
-              __dirname + "/test-rolling-stream-with-existing-files.1.1",
-              __dirname + "/test-rolling-stream-with-existing-files.1"
+              path.join(
+                __dirname,
+                "/test-rolling-stream-with-existing-files.11"
+              ),
+              path.join(
+                __dirname,
+                "/test-rolling-stream-with-existing-files.20"
+              ),
+              path.join(
+                __dirname,
+                "/test-rolling-stream-with-existing-files.-1"
+              ),
+              path.join(
+                __dirname,
+                "/test-rolling-stream-with-existing-files.1.1"
+              ),
+              path.join(__dirname, "/test-rolling-stream-with-existing-files.1")
             ],
             create,
             function(err) {
               if (err) done(err);
 
               var stream = new RollingFileStream(
-                __dirname + "/test-rolling-stream-with-existing-files",
+                path.join(
+                  __dirname,
+                  "/test-rolling-stream-with-existing-files"
+                ),
                 18,
                 5
               );
@@ -494,18 +514,18 @@ describe("RollingFileStream", function() {
     after(function(done) {
       async.forEach(
         [
-          __dirname + "/test-rolling-stream-with-existing-files.-1",
-          __dirname + "/test-rolling-stream-with-existing-files",
-          __dirname + "/test-rolling-stream-with-existing-files.1.1",
-          __dirname + "/test-rolling-stream-with-existing-files.0",
-          __dirname + "/test-rolling-stream-with-existing-files.1",
-          __dirname + "/test-rolling-stream-with-existing-files.2",
-          __dirname + "/test-rolling-stream-with-existing-files.3",
-          __dirname + "/test-rolling-stream-with-existing-files.4",
-          __dirname + "/test-rolling-stream-with-existing-files.5",
-          __dirname + "/test-rolling-stream-with-existing-files.6",
-          __dirname + "/test-rolling-stream-with-existing-files.11",
-          __dirname + "/test-rolling-stream-with-existing-files.20"
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.-1"),
+          path.join(__dirname, "/test-rolling-stream-with-existing-files"),
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.1.1"),
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.0"),
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.1"),
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.2"),
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.3"),
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.4"),
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.5"),
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.6"),
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.11"),
+          path.join(__dirname, "/test-rolling-stream-with-existing-files.20")
         ],
         remove,
         done


### PR DESCRIPTION
Rearranged functions in `RollingFileWriteStream` so that they are in the order they get used, which should make it easier to read the code from top to bottom. Changed a lot of test code which was using string concatenation for file paths to use `path.join`.