### PR TITLE
Remove async lib from dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "@commitlint/cli": "^8.1.0",
     "@commitlint/config-conventional": "^8.1.0",
-    "async": "^2.6.3",
     "eslint": "^6.0.1",
     "husky": "^3.0.0",
     "mocha": "^6.1.4",

--- a/test/DateRollingFileStream-test.js
+++ b/test/DateRollingFileStream-test.js
@@ -5,7 +5,7 @@
 
 require("should");
 
-const fs = require("fs"),
+const fs = require("fs-extra"),
   path = require("path"),
   zlib = require("zlib"),
   proxyquire = require("proxyquire").noPreserveCache(),
@@ -22,109 +22,96 @@ const DateRollingFileStream = proxyquire("../lib/DateRollingFileStream", {
   "./RollingFileWriteStream": RollingFileWriteStream
 });
 
-function remove(filename, cb) {
-  fs.unlink(filename, function() {
-    cb();
-  });
-}
+const gunzip = util.promisify(zlib.gunzip);
+const remove = filename => fs.unlink(filename).catch(() => {});
 
 describe("DateRollingFileStream", function() {
   describe("arguments", function() {
-    var stream;
+    let stream;
 
-    before(function(done) {
+    before(function() {
       stream = new DateRollingFileStream(
         path.join(__dirname, "test-date-rolling-file-stream-1"),
         "yyyy-MM-dd.hh"
       );
-      done();
     });
 
-    after(function(done) {
-      remove(path.join(__dirname, "test-date-rolling-file-stream-1"), done);
+    after(async function() {
+      await remove(path.join(__dirname, "test-date-rolling-file-stream-1"));
     });
 
-    it("should take a filename and a pattern and return a WritableStream", function(done) {
+    it("should take a filename and a pattern and return a WritableStream", function() {
       stream.filename.should.eql(
         path.join(__dirname, "test-date-rolling-file-stream-1")
       );
       stream.options.pattern.should.eql("yyyy-MM-dd.hh");
       stream.should.be.instanceOf(streams.Writable);
-      done();
     });
 
-    it("with default settings for the underlying stream", function(done) {
+    it("with default settings for the underlying stream", function() {
       stream.currentFileStream.mode.should.eql(420);
       stream.currentFileStream.flags.should.eql("a");
-      done();
     });
   });
 
   describe("default arguments", function() {
     var stream;
 
-    before(function(done) {
+    before(function() {
       stream = new DateRollingFileStream(
         path.join(__dirname, "test-date-rolling-file-stream-2")
       );
-      done();
     });
 
-    after(function(done) {
-      remove(path.join(__dirname, "test-date-rolling-file-stream-2"), done);
+    after(async function() {
+      await remove(path.join(__dirname, "test-date-rolling-file-stream-2"));
     });
 
-    it("should have pattern of .yyyy-MM-dd", function(done) {
+    it("should have pattern of .yyyy-MM-dd", function() {
       stream.options.pattern.should.eql("yyyy-MM-dd");
-      done();
     });
   });
 
   describe("with stream arguments", function() {
     var stream;
 
-    before(function(done) {
+    before(function() {
       stream = new DateRollingFileStream(
         path.join(__dirname, "test-date-rolling-file-stream-3"),
         "yyyy-MM-dd",
         { mode: parseInt("0666", 8) }
       );
-      done();
     });
 
-    after(function(done) {
-      remove(path.join(__dirname, "test-date-rolling-file-stream-3"), done);
+    after(async function() {
+      await remove(path.join(__dirname, "test-date-rolling-file-stream-3"));
     });
 
-    it("should pass them to the underlying stream", function(done) {
+    it("should pass them to the underlying stream", function() {
       stream.theStream.mode.should.eql(parseInt("0666", 8));
-      done();
     });
   });
 
   describe("with stream arguments but no pattern", function() {
     var stream;
 
-    before(function(done) {
+    before(function() {
       stream = new DateRollingFileStream(
         path.join(__dirname, "test-date-rolling-file-stream-4"),
         { mode: parseInt("0666", 8) }
       );
-      done();
     });
 
-    after(function(done) {
-      remove(path.join(__dirname, "test-date-rolling-file-stream-4"), done);
+    after(async function() {
+      await remove(path.join(__dirname, "test-date-rolling-file-stream-4"));
     });
 
-    it("should pass them to the underlying stream", function(done) {
+    it("should pass them to the underlying stream", function() {
       stream.theStream.mode.should.eql(parseInt("0666", 8));
-      done();
     });
 
-    it("should use default pattern", function(done) {
+    it("should use default pattern", function() {
       stream.options.pattern.should.eql("yyyy-MM-dd");
-      done();
     });
   });
 
@@ -140,19 +127,16 @@ describe("DateRollingFileStream", function() {
       stream.write("First message\n", "utf8", done);
     });
 
-    after(function(done) {
-      remove(path.join(__dirname, "test-date-rolling-file-stream-5"), done);
+    after(async function() {
+      await remove(path.join(__dirname, "test-date-rolling-file-stream-5"));
     });
 
-    it("should create a file with the base name", function(done) {
-      fs.readFile(
+    it("should create a file with the base name", async function() {
+      const contents = await fs.readFile(
         path.join(__dirname, "test-date-rolling-file-stream-5"),
-        "utf8",
-        function(err, contents) {
-          contents.should.eql("First message\n");
-          done(err);
-        }
+        "utf8"
       );
+      contents.should.eql("First message\n");
     });
 
     describe("when the day changes", function() {
@@ -161,56 +145,40 @@ describe("DateRollingFileStream", function() {
         stream.write("Second message\n", "utf8", done);
       });
 
-      after(function(done) {
-        remove(
-          path.join(__dirname, "test-date-rolling-file-stream-5.2012-09-12"),
-          done
+      after(async function() {
+        await remove(
+          path.join(__dirname, "test-date-rolling-file-stream-5.2012-09-12")
         );
       });
 
       describe("the number of files", function() {
-        var files = [];
-
-        before(function(done) {
-          fs.readdir(__dirname, function(err, list) {
-            files = list;
-            done(err);
-          });
-        });
-
-        it("should be two", function(done) {
+        it("should be two", async function() {
+          const files = await fs.readdir(__dirname);
           files
-            .filter(function(file) {
-              return file.indexOf("test-date-rolling-file-stream-5") > -1;
-            })
+            .filter(
+              file => file.indexOf("test-date-rolling-file-stream-5") > -1
+            )
             .should.have.length(2);
-          done();
         });
       });
 
       describe("the file without a date", function() {
-        it("should contain the second message", function(done) {
-          fs.readFile(
+        it("should contain the second message", async function() {
+          const contents = await fs.readFile(
             path.join(__dirname, "test-date-rolling-file-stream-5"),
-            "utf8",
-            function(err, contents) {
-              contents.should.eql("Second message\n");
-              done(err);
-            }
+            "utf8"
           );
+          contents.should.eql("Second message\n");
         });
       });
 
       describe("the file with the date", function() {
-        it("should contain the first message", function(done) {
-          fs.readFile(
+        it("should contain the first message", async function() {
+          const contents = await fs.readFile(
             path.join(__dirname, "test-date-rolling-file-stream-5.2012-09-12"),
-            "utf8",
-            function(err, contents) {
-              contents.should.eql("First message\n");
-              done(err);
-            }
+            "utf8"
           );
+          contents.should.eql("First message\n");
         });
       });
     });
@@ -219,48 +187,45 @@ describe("DateRollingFileStream", function() {
   describe("with alwaysIncludePattern", function() {
     var stream;
 
-    before(function(done) {
+    before(async function() {
       fakeNow = new Date(2012, 8, 12, 11, 10, 12);
-      remove(
+      await remove(
         path.join(
           __dirname,
           "test-date-rolling-file-stream-pattern.2012-09-12-11.log"
-        ),
-        function() {
-          stream = new DateRollingFileStream(
-            path.join(__dirname, "test-date-rolling-file-stream-pattern"),
-            ".yyyy-MM-dd-hh.log",
-            { alwaysIncludePattern: true }
-          );
-          setTimeout(function() {
-            stream.write("First message\n", "utf8", done);
-          }, 50);
-        }
+        )
+      );
+      stream = new DateRollingFileStream(
+        path.join(__dirname, "test-date-rolling-file-stream-pattern"),
+        ".yyyy-MM-dd-hh.log",
+        { alwaysIncludePattern: true }
+      );
+
+      await new Promise(resolve => {
+        setTimeout(function() {
+          stream.write("First message\n", "utf8", () => resolve());
+        }, 50);
+      });
+    });
+
+    after(async function() {
+      await remove(
+        path.join(
+          __dirname,
+          "test-date-rolling-file-stream-pattern.2012-09-12-11.log"
+        )
       );
     });
 
-    after(function(done) {
-      remove(
+    it("should create a file with the pattern set", async function() {
+      const contents = await fs.readFile(
         path.join(
           __dirname,
           "test-date-rolling-file-stream-pattern.2012-09-12-11.log"
         ),
-        done
+        "utf8"
       );
-    });
-
-    it("should create a file with the pattern set", function(done) {
-      fs.readFile(
-        path.join(
-          __dirname,
-          "test-date-rolling-file-stream-pattern.2012-09-12-11.log"
-        ),
-        "utf8",
-        function(err, contents) {
-          contents.should.eql("First message\n");
-          done(err);
-        }
-      );
+      contents.should.eql("First message\n");
     });
 
     describe("when the day changes", function() {
@@ -269,60 +234,49 @@ describe("DateRollingFileStream", function() {
         stream.write("Second message\n", "utf8", done);
       });
 
-      after(function(done) {
-        remove(
+      after(async function() {
+        await remove(
           path.join(
             __dirname,
             "test-date-rolling-file-stream-pattern.2012-09-12-12.log"
-          ),
-          done
+          )
         );
       });
 
       describe("the number of files", function() {
-        it("should be two", function(done) {
-          fs.readdir(__dirname, function(err, files) {
-            files
-              .filter(function(file) {
-                return (
-                  file.indexOf("test-date-rolling-file-stream-pattern") > -1
-                );
-              })
-              .should.have.length(2);
-            done(err);
-          });
+        it("should be two", async function() {
+          const files = await fs.readdir(__dirname);
+          files
+            .filter(
+              file => file.indexOf("test-date-rolling-file-stream-pattern") > -1
+            )
+            .should.have.length(2);
         });
       });
 
       describe("the file with the later date", function() {
-        it("should contain the second message", function(done) {
-          fs.readFile(
+        it("should contain the second message", async function() {
+          const contents = await fs.readFile(
             path.join(
               __dirname,
               "test-date-rolling-file-stream-pattern.2012-09-12-12.log"
             ),
-            "utf8",
-            function(err, contents) {
-              contents.should.eql("Second message\n");
-              done(err);
-            }
+            "utf8"
           );
+          contents.should.eql("Second message\n");
         });
       });
 
       describe("the file with the date", function() {
-        it("should contain the first message", function(done) {
-          fs.readFile(
+        it("should contain the first message", async function() {
+          const contents = await fs.readFile(
             path.join(
               __dirname,
               "test-date-rolling-file-stream-pattern.2012-09-12-11.log"
             ),
-            "utf8",
-            function(err, contents) {
-              contents.should.eql("First message\n");
-              done(err);
-            }
+            "utf8"
           );
+          contents.should.eql("First message\n");
         });
       });
     });
@@ -345,36 +299,24 @@ describe("DateRollingFileStream", function() {
         stream.write("Second message\n", "utf8", done);
       });
 
-      it("should be two files (it should not get confused by indexes)", function(done) {
-        fs.readdir(__dirname, function(err, files) {
-          var logFiles = files.filter(function(file) {
-            return file.indexOf("digits.log") > -1;
-          });
-          logFiles.should.have.length(2);
+      it("should be two files (it should not get confused by indexes)", async function() {
+        const files = await fs.readdir(__dirname);
+        var logFiles = files.filter(file => file.indexOf("digits.log") > -1);
+        logFiles.should.have.length(2);
 
-          fs.readFile(
-            path.join(__dirname, "digits.log.20120912"),
-            "utf8",
-            (err, contents) => {
-              contents.should.eql("First message\n");
-              fs.readFile(
-                path.join(__dirname, "digits.log"),
-                "utf8",
-                (e, c) => {
-                  c.should.eql("Second message\n");
-                  done(err || e);
-                }
-              );
-            }
-          );
-        });
+        const contents = await fs.readFile(
+          path.join(__dirname, "digits.log.20120912"),
+          "utf8"
+        );
+        contents.should.eql("First message\n");
+        const c = await fs.readFile(path.join(__dirname, "digits.log"), "utf8");
+        c.should.eql("Second message\n");
       });
     });
 
-    after(function(done) {
-      remove(path.join(__dirname, "digits.log"), function() {
-        remove(path.join(__dirname, "digits.log.20120912"), done);
-      });
+    after(async function() {
+      await remove(path.join(__dirname, "digits.log"));
+      await remove(path.join(__dirname, "digits.log.20120912"));
     });
   });
 
@@ -397,34 +339,29 @@ describe("DateRollingFileStream", function() {
         stream.write("Second message\n", "utf8", done);
       });
 
-      it("should be two files, one compressed", function(done) {
-        fs.readdir(__dirname, function(err, files) {
-          var logFiles = files.filter(function(file) {
-            return file.indexOf("compressed.log") > -1;
-          });
-          logFiles.should.have.length(2);
+      it("should be two files, one compressed", async function() {
+        const files = await fs.readdir(__dirname);
+        var logFiles = files.filter(
+          file => file.indexOf("compressed.log") > -1
+        );
+        logFiles.should.have.length(2);
 
-          zlib.gunzip(
-            fs.readFileSync(
-              path.join(__dirname, "compressed.log.2012-09-12.gz")
-            ),
-            function(err, contents) {
-              contents.toString("utf8").should.eql("First message\n");
-              fs.readFileSync(
-                path.join(__dirname, "compressed.log"),
-                "utf8"
-              ).should.eql("Second message\n");
-              done(err);
-            }
-          );
-        });
+        const gzipped = await fs.readFile(
+          path.join(__dirname, "compressed.log.2012-09-12.gz")
+        );
+        const contents = await gunzip(gzipped);
+        contents.toString("utf8").should.eql("First message\n");
+
+        (await fs.readFile(
+          path.join(__dirname, "compressed.log"),
+          "utf8"
+        )).should.eql("Second message\n");
       });
     });
 
-    after(function(done) {
-      remove(path.join(__dirname, "compressed.log"), function() {
-        remove(path.join(__dirname, "compressed.log.2012-09-12.gz"), done);
-      });
+    after(async function() {
+      await remove(path.join(__dirname, "compressed.log"));
+      await remove(path.join(__dirname, "compressed.log.2012-09-12.gz"));
     });
   });
 
@@ -447,29 +384,25 @@ describe("DateRollingFileStream", function() {
         stream.write("Second message\n", "utf8", done);
       });
 
-      it("should be two files", function(done) {
-        fs.readdir(__dirname, function(err, files) {
-          var logFiles = files.filter(function(file) {
-            return file.indexOf("keepFileExt") > -1;
-          });
-          logFiles.should.have.length(2);
-          fs.readFileSync(
-            path.join(__dirname, "keepFileExt.2012-09-12.log"),
-            "utf8"
-          ).should.eql("First message\n");
-          fs.readFileSync(
-            path.join(__dirname, "keepFileExt.log"),
-            "utf8"
-          ).should.eql("Second message\n");
-          done(err);
-        });
+      it("should be two files", async function() {
+        const files = await fs.readdir(__dirname);
+        var logFiles = files.filter(file => file.indexOf("keepFileExt") > -1);
+        logFiles.should.have.length(2);
+
+        (await fs.readFile(
+          path.join(__dirname, "keepFileExt.2012-09-12.log"),
+          "utf8"
+        )).should.eql("First message\n");
+        (await fs.readFile(
+          path.join(__dirname, "keepFileExt.log"),
+          "utf8"
+        )).should.eql("Second message\n");
       });
     });
 
-    after(function(done) {
-      remove(path.join(__dirname, "keepFileExt.log"), function() {
-        remove(path.join(__dirname, "keepFileExt.2012-09-12.log"), done);
-      });
+    after(async function() {
+      await remove(path.join(__dirname, "keepFileExt.log"));
+      await remove(path.join(__dirname, "keepFileExt.2012-09-12.log"));
     });
   });
 
@@ -492,37 +425,30 @@ describe("DateRollingFileStream", function() {
         stream.write("Second message\n", "utf8", done);
       });
 
-      it("should be two files, one compressed", function(done) {
-        fs.readdir(__dirname, function(err, files) {
-          var logFiles = files.filter(function(file) {
-            return file.indexOf("compressedAndKeepExt") > -1;
-          });
-          logFiles.should.have.length(2);
+      it("should be two files, one compressed", async function() {
+        const files = await fs.readdir(__dirname);
+        var logFiles = files.filter(
+          file => file.indexOf("compressedAndKeepExt") > -1
+        );
+        logFiles.should.have.length(2);
 
-          zlib.gunzip(
-            fs.readFileSync(
-              path.join(__dirname, "compressedAndKeepExt.2012-09-12.log.gz")
-            ),
-            function(err, contents) {
-              contents.toString("utf8").should.eql("First message\n");
-              fs.readFileSync(
-                path.join(__dirname, "compressedAndKeepExt.log"),
-                "utf8"
-              ).should.eql("Second message\n");
-              done(err);
-            }
-          );
-        });
+        const gzipped = await fs.readFile(
+          path.join(__dirname, "compressedAndKeepExt.2012-09-12.log.gz")
+        );
+        const contents = await gunzip(gzipped);
+        contents.toString("utf8").should.eql("First message\n");
+        (await fs.readFile(
+          path.join(__dirname, "compressedAndKeepExt.log"),
+          "utf8"
+        )).should.eql("Second message\n");
       });
     });
 
-    after(function(done) {
-      remove(path.join(__dirname, "compressedAndKeepExt.log"), function() {
-        remove(
-          path.join(__dirname, "compressedAndKeepExt.2012-09-12.log.gz"),
-          done
-        );
-      });
+    after(async function() {
+      await remove(path.join(__dirname, "compressedAndKeepExt.log"));
+      await remove(
+        path.join(__dirname, "compressedAndKeepExt.2012-09-12.log.gz")
+      );
     });
   });
 
@@ -581,30 +507,21 @@ describe("DateRollingFileStream", function() {
         stream.write("Second message\n", "utf8", done);
       });
 
-      it("should be daysToKeep + 1 files left from numOriginalLogs", function(done) {
-        fs.readdir(__dirname, function(err, files) {
-          var logFiles = files.filter(function(file) {
-            return file.indexOf("daysToKeep.log") > -1;
-          });
-          logFiles.should.have.length(daysToKeep + 1);
-          done(err);
-        });
+      it("should be daysToKeep + 1 files left from numOriginalLogs", async function() {
+        const files = await fs.readdir(__dirname);
+        var logFiles = files.filter(
+          file => file.indexOf("daysToKeep.log") > -1
+        );
+        logFiles.should.have.length(daysToKeep + 1);
       });
     });
 
-    after(function(done) {
-      fs.readdir(__dirname, function(err, files) {
-        var logFiles = files.filter(function(file) {
-          return file.indexOf("daysToKeep.log") > -1;
-        });
-        async.each(
-          logFiles,
-          (logFile, nextCallback) => {
-            remove(path.join(__dirname, logFile), nextCallback);
-          },
-          done
-        );
-      });
+    after(async function() {
+      const files = await fs.readdir(__dirname);
+      const logFiles = files
+        .filter(file => file.indexOf("daysToKeep.log") > -1)
+        .map(f => remove(path.join(__dirname, f)));
+      await Promise.all(logFiles);
     });
   });
 
@@ -680,32 +597,21 @@ describe("DateRollingFileStream", function() {
         stream.write("New file message\n", "utf8", done);
       });
 
-      it("should be 4 files left from original 3", function(done) {
-        fs.readdir(__dirname, function(err, files) {
-          var logFiles = files.filter(function(file) {
-            return file.indexOf("compressedDaysToKeep.log") > -1;
-          });
-          logFiles.should.have.length(daysToKeep + 1);
-          done(err);
-        });
+      it("should be 4 files left from original 3", async function() {
+        const files = await fs.readdir(__dirname);
+        var logFiles = files.filter(
+          file => file.indexOf("compressedDaysToKeep.log") > -1
+        );
+        logFiles.should.have.length(daysToKeep + 1);
       });
     });
 
-    after(function(done) {
-      fs.readdir(__dirname, function(err, files) {
-        var logFiles = files.filter(function(file) {
-          return file.indexOf("compressedDaysToKeep.log") > -1;
-        });
-        async.each(
-          logFiles,
-          function(logFile, nextCallback) {
-            remove(path.join(__dirname, logFile), nextCallback);
-          },
-          function(err) {
-            done(err);
-          }
-        );
-      });
+    after(async function() {
+      const files = await fs.readdir(__dirname);
+      const logFiles = files
+        .filter(file => file.indexOf("compressedDaysToKeep.log") > -1)
+        .map(f => remove(path.join(__dirname, f)));
+      await Promise.all(logFiles);
     });
   });
 });

--- a/test/RollingFileWriteStream-test.js
+++ b/test/RollingFileWriteStream-test.js
@@ -2,7 +2,6 @@ require("should");
 
 const path = require("path");
 const zlib = require("zlib");
-const async = require("async");
 const stream = require("stream");
 const fs = require("fs-extra");
 const proxyquire = require("proxyquire").noPreserveCache();
@@ -119,17 +118,21 @@ describe("RollingFileWriteStream", () => {
     const fileObj = generateTestFile("noExtension");
     let s;
 
-    before(done => {
+    before(async () => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
         pattern: "yyyy-MM-dd",
         maxSize: 5
       });
-      const flows = Array.from(Array(38).keys()).map(i => cb => {
+      const flows = Array.from(Array(38).keys()).map(i => () => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5, 10), 10, 37, 11);
-        s.write(i.toString(), "utf8", cb);
+        return new Promise(resolve => {
+          s.write(i.toString(), "utf8", () => resolve());
+        });
       });
-      async.waterfall(flows, () => done());
+      for (let i = 0; i < flows.length; i += 1) {
+        await flows[i]();
+      }
     });
 
     after(done => {
@@ -274,13 +277,16 @@ describe("RollingFileWriteStream", () => {
     const fileObj = generateTestFile();
     let s;
 
-    before(done => {
-      const flows = Array.from(Array(3).keys()).map(() => cb => {
+    before(async () => {
+      const flows = Array.from(Array(3).keys()).map(() => () => {
         s = new RollingFileWriteStream(fileObj.path);
-        s.write("abc", "utf8", cb);
-        s.end();
+        return new Promise(resolve => {
+          s.end("abc", "utf8", () => resolve());
+        });
       });
-      async.waterfall(flows, () => done());
+      for (let i = 0; i < flows.length; i += 1) {
+        await flows[i]();
+      }
     });
 
     after(() => {
@@ -308,17 +314,21 @@ describe("RollingFileWriteStream", () => {
     const fileObj = generateTestFile("withExtension.log");
     let s;
 
-    before(done => {
+    before(async () => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
         pattern: "yyyy-MM-dd",
         maxSize: 5
       });
-      const flows = Array.from(Array(38).keys()).map(i => cb => {
+      const flows = Array.from(Array(38).keys()).map(i => () => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 10, 10), 10, 37, 11);
-        s.write(i.toString(), "utf8", cb);
+        return new Promise(resolve => {
+          s.write(i.toString(), "utf8", () => resolve());
+        });
       });
-      async.waterfall(flows, () => done());
+      for (let i = 0; i < flows.length; i += 1) {
+        await flows[i]();
+      }
     });
 
     after(done => {
@@ -463,17 +473,21 @@ describe("RollingFileWriteStream", () => {
     const fileObj = generateTestFile();
     let s;
 
-    before(done => {
+    before(async () => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
         maxSize: 5,
         numToKeep: 3
       });
-      const flows = Array.from(Array(38).keys()).map(i => cb => {
+      const flows = Array.from(Array(38).keys()).map(i => () => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5), 10, 37, 11);
-        s.write(i.toString(), "utf8", cb);
+        return new Promise(resolve => {
+          s.write(i.toString(), "utf8", () => resolve());
+        });
       });
-      async.waterfall(flows, () => done());
+      for (let i = 0; i < flows.length; i += 1) {
+        await flows[i]();
+      }
     });
 
     after(() => {
@@ -528,18 +542,22 @@ describe("RollingFileWriteStream", () => {
     const fileObj = generateTestFile();
     let s;
 
-    before(done => {
+    before(async () => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
         maxSize: 5,
         pattern: "yyyy-MM-dd",
         numToKeep: 3
       });
-      const flows = Array.from(Array(38).keys()).map(i => cb => {
+      const flows = Array.from(Array(38).keys()).map(i => () => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 10), 10, 37, 11);
-        s.write(i.toString(), "utf8", cb);
+        return new Promise(resolve => {
+          s.write(i.toString(), "utf8", () => resolve());
+        });
       });
-      async.waterfall(flows, () => done());
+      for (let i = 0; i < flows.length; i += 1) {
+        await flows[i]();
+      }
     });
 
     after(() => {
@@ -594,17 +612,21 @@ describe("RollingFileWriteStream", () => {
     const fileObj = generateTestFile();
     let s;
 
-    before(done => {
+    before(async () => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
         maxSize: 5,
         pattern: "dd-MM-yyyy"
       });
-      const flows = Array.from(Array(8).keys()).map(i => cb => {
+      const flows = Array.from(Array(8).keys()).map(i => () => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5, 10), 10, 37, 11);
-        s.write(i.toString(), "utf8", cb);
+        return new Promise(resolve => {
+          s.write(i.toString(), "utf8", () => resolve());
+        });
       });
-      async.waterfall(flows, () => done());
+      for (let i = 0; i < flows.length; i += 1) {
+        await flows[i]();
+      }
     });
 
     after(done => {
@@ -637,18 +659,22 @@ describe("RollingFileWriteStream", () => {
     const fileObj = generateTestFile();
     let s;
 
-    before(done => {
+    before(async () => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
         maxSize: 5,
         pattern: "yyyy-MM-dd",
         compress: true
       });
-      const flows = Array.from(Array(8).keys()).map(i => cb => {
+      const flows = Array.from(Array(8).keys()).map(i => () => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5, 10), 10, 37, 11);
-        s.write(i.toString(), "utf8", cb);
+        return new Promise(resolve => {
+          s.write(i.toString(), "utf8", () => resolve());
+        });
       });
-      async.waterfall(flows, () => done());
+      for (let i = 0; i < flows.length; i += 1) {
+        await flows[i]();
+      }
     });
 
     after(() => {
@@ -686,18 +712,22 @@ describe("RollingFileWriteStream", () => {
     const fileObj = generateTestFile("keepFileExt.log");
     let s;
 
-    before(done => {
+    before(async () => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
         pattern: "yyyy-MM-dd",
         maxSize: 5,
         keepFileExt: true
       });
-      const flows = Array.from(Array(8).keys()).map(i => cb => {
+      const flows = Array.from(Array(8).keys()).map(i => () => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5, 10), 10, 37, 11);
-        s.write(i.toString(), "utf8", cb);
+        return new Promise(resolve => {
+          s.write(i.toString(), "utf8", () => resolve());
+        });
       });
-      async.waterfall(flows, () => done());
+      for (let i = 0; i < flows.length; i += 1) {
+        await flows[i]();
+      }
     });
 
     after(done => {
@@ -733,7 +763,7 @@ describe("RollingFileWriteStream", () => {
     const fileObj = generateTestFile("keepFileExt.log");
     let s;
 
-    before(done => {
+    before(async () => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
         maxSize: 5,
@@ -741,11 +771,15 @@ describe("RollingFileWriteStream", () => {
         keepFileExt: true,
         compress: true
       });
-      const flows = Array.from(Array(8).keys()).map(i => cb => {
+      const flows = Array.from(Array(8).keys()).map(i => () => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5, 10), 10, 37, 11);
-        s.write(i.toString(), "utf8", cb);
+        return new Promise(resolve => {
+          s.write(i.toString(), "utf8", () => resolve());
+        });
       });
-      async.waterfall(flows, () => done());
+      for (let i = 0; i < flows.length; i += 1) {
+        await flows[i]();
+      }
     });
 
     after(done => {
@@ -784,7 +818,7 @@ describe("RollingFileWriteStream", () => {
     const fileObj = generateTestFile("keepFileExt.log");
     let s;
 
-    before(done => {
+    before(async () => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
         maxSize: 5,
@@ -792,11 +826,15 @@ describe("RollingFileWriteStream", () => {
         keepFileExt: true,
         alwaysIncludePattern: true
       });
-      const flows = Array.from(Array(8).keys()).map(i => cb => {
+      const flows = Array.from(Array(8).keys()).map(i => () => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5, 10), 10, 37, 11);
-        s.write(i.toString(), "utf8", cb);
+        return new Promise(resolve => {
+          s.write(i.toString(), "utf8", () => resolve());
+        });
       });
-      async.waterfall(flows, () => done());
+      for (let i = 0; i < flows.length; i += 1) {
+        await flows[i]();
+      }
     });
 
     after(done => {
@@ -838,7 +876,7 @@ describe("RollingFileWriteStream", () => {
     const fileObj = generateTestFile("keepFileExt.log");
     let s;
 
-    before(done => {
+    before(async () => {
       fakeNow = new Date(2012, 8, 12, 10, 37, 11);
       s = new RollingFileWriteStream(fileObj.path, {
         maxSize: 5,
@@ -847,11 +885,15 @@ describe("RollingFileWriteStream", () => {
         alwaysIncludePattern: true,
         pattern: "yyyy-MM-dd"
       });
-      const flows = Array.from(Array(38).keys()).map(i => cb => {
+      const flows = Array.from(Array(38).keys()).map(i => () => {
         fakeNow = new Date(2012, 8, 12 + parseInt(i / 5, 10), 10, 37, 11);
-        s.write(i.toString(), "utf8", cb);
+        return new Promise(resolve => {
+          s.write(i.toString(), "utf8", () => resolve());
+        });
       });
-      async.waterfall(flows, () => done());
+      for (let i = 0; i < flows.length; i += 1) {
+        await flows[i]();
+      }
     });
 
     after(done => {


### PR DESCRIPTION
I've replaced the async lib with async/await in the tests as well. It made them easier to understand.