### PR TITLE
chore: added _final method, fixed tests for windows

### DIFF
--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -111,6 +111,10 @@ class RollingFileWriteStream extends Writable {
     return options;
   }
 
+  _final(callback) {
+    this.currentFileStream.end("", this.options.encoding, callback);
+  }
+
   _write(chunk, encoding, callback) {
     this._shouldRoll().then(() => {
       debug(

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "codecheck": "eslint 'lib/*.js'",
+    "codecheck": "eslint \"lib/*.js\" \"test/*.js\"",
     "prepublishOnly": "npm test",
     "pretest": "npm run codecheck",
     "clean": "rm -rf node_modules/",

--- a/test/RollingFileWriteStream-test.js
+++ b/test/RollingFileWriteStream-test.js
@@ -93,8 +93,7 @@ describe("RollingFileWriteStream", () => {
     });
 
     after(() => {
-      s.end();
-      fs.removeSync(fileObj.dir);
+      s.end(() => fs.removeSync(fileObj.dir));
     });
 
     it("should take a filename and options, return Writable", () => {
@@ -136,8 +135,10 @@ describe("RollingFileWriteStream", () => {
     });
 
     after(done => {
-      fs.removeSync(fileObj.dir);
-      done();
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();  
+      });
     });
 
     it("should rotate using filename with no extension", () => {
@@ -332,8 +333,10 @@ describe("RollingFileWriteStream", () => {
     });
 
     after(done => {
-      fs.removeSync(fileObj.dir);
-      done();
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();  
+      })
     });
 
     it("should rotate files within the day, and when the day changes", () => {
@@ -490,9 +493,11 @@ describe("RollingFileWriteStream", () => {
       }
     });
 
-    after(() => {
-      s.end();
-      fs.removeSync(fileObj.dir);
+    after(done => {
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();
+      });
     });
 
     it("should rotate with at most 3 backup files not including the hot one", () => {
@@ -560,9 +565,11 @@ describe("RollingFileWriteStream", () => {
       }
     });
 
-    after(() => {
-      s.end();
-      fs.removeSync(fileObj.dir);
+    after(done => {
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();
+      });
     });
 
     it("should rotate with at most 3 backup files not including the hot one", () => {
@@ -677,9 +684,11 @@ describe("RollingFileWriteStream", () => {
       }
     });
 
-    after(() => {
-      s.end();
-      fs.removeSync(fileObj.dir);
+    after(done => {
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();
+      });
     });
 
     it("should rotate with gunzip", () => {
@@ -731,9 +740,10 @@ describe("RollingFileWriteStream", () => {
     });
 
     after(done => {
-      s.end();
-      fs.removeSync(fileObj.dir);
-      done();
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();  
+      });
     });
 
     it("should rotate with the same extension", () => {
@@ -783,9 +793,10 @@ describe("RollingFileWriteStream", () => {
     });
 
     after(done => {
-      s.end();
-      fs.removeSync(fileObj.dir);
-      done();
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();  
+      });
     });
 
     it("should rotate with the same extension", () => {
@@ -838,9 +849,10 @@ describe("RollingFileWriteStream", () => {
     });
 
     after(done => {
-      s.end();
-      fs.removeSync(fileObj.dir);
-      done();
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();  
+      });
     });
 
     it("should rotate with the same extension and keep date in the filename", () => {
@@ -897,9 +909,10 @@ describe("RollingFileWriteStream", () => {
     });
 
     after(done => {
-      s.end();
-      fs.removeSync(fileObj.dir);
-      done();
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();  
+      });
     });
 
     it("should rotate every day", () => {
@@ -1089,9 +1102,11 @@ describe("RollingFileWriteStream", () => {
       s.write("now", "utf8", done);
     });
 
-    after(() => {
-      s.end();
-      fs.removeSync(fileObj.dir);
+    after(done => {
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();
+      });
     });
 
     it("should use write in the old file if not reach the maxSize limit", () => {
@@ -1120,9 +1135,11 @@ describe("RollingFileWriteStream", () => {
       s.write("three\n", "utf8", done); // this should be in a new file.
     });
 
-    after(() => {
-      s.end();
-      fs.removeSync(fileObj.dir);
+    after(done => {
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();
+      });
     });
 
     it("should respect the existing file size", () => {
@@ -1157,9 +1174,11 @@ describe("RollingFileWriteStream", () => {
       s.write("three\n", "utf8", done); // this should be in a new file.
     });
 
-    after(() => {
-      s.end();
-      fs.removeSync(fileObj.dir);
+    after(done => {
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();
+      });
     });
 
     it("should respect the existing file size", () => {
@@ -1197,9 +1216,11 @@ describe("RollingFileWriteStream", () => {
       s.write("three\n", "utf8", done); // base.3 -> base.4, base.2 -> base.3, base.1 -> base.2, base -> base.1
     });
 
-    after(() => {
-      s.end();
-      fs.removeSync(fileObj.dir);
+    after(done => {
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();
+      });
     });
 
     it("should rotate the old file indices", () => {
@@ -1247,9 +1268,11 @@ describe("RollingFileWriteStream", () => {
       s.write("It is now Sept 13, 2012.\n", "utf8", done); // this should be in a new file.
     });
 
-    after(() => {
-      s.end();
-      fs.removeSync(fileObj.dir);
+    after(done => {
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();
+      });
     });
 
     it("should respect the existing file date", () => {
@@ -1279,9 +1302,11 @@ describe("RollingFileWriteStream", () => {
       s.write("there should only be this\n", "utf8", done);
     });
 
-    after(() => {
-      s.end();
-      fs.removeSync(fileObj.dir);
+    after(done => {
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();
+      });
     });
 
     it("should ignore the existing file size", () => {
@@ -1309,9 +1334,11 @@ describe("RollingFileWriteStream", () => {
       s.write("test", "utf8", done);
     });
 
-    after(() => {
-      s.end();
-      fs.removeSync(fileObj.dir);
+    after(done => {
+      s.end(() => {
+        fs.removeSync(fileObj.dir);
+        done();
+      });
     });
 
     it("should create the dir", () => {
@@ -1333,9 +1360,11 @@ describe("RollingFileWriteStream", () => {
       s.write("this should not cause any problems", "utf8", done);
     });
 
-    after(() => {
-      s.end();
-      fs.removeSync("test.log");
+    after(done => {
+      s.end(() => {
+        fs.removeSync("test.log");
+        done();
+      });
     });
 
     it("should use process.cwd() as the dir", () => {
@@ -1372,9 +1401,11 @@ describe("RollingFileWriteStream", () => {
       s.write("this should not cause any problems", "utf8", done);
     });
 
-    after(() => {
-      s.end();
-      fs.removeSync("test-events.log");
+    after(done => {
+      s.end(() => {
+        fs.removeSync("test-events.log");
+        done();
+      });
     });
 
     it("should emit the error event of the underlying stream", done => {

--- a/test/fileNameFormatter-test.js
+++ b/test/fileNameFormatter-test.js
@@ -1,4 +1,5 @@
 require("should");
+const { normalize } = require("path");
 
 describe("fileNameFormatter", () => {
   describe("without a date", () => {
@@ -13,15 +14,15 @@ describe("fileNameFormatter", () => {
     it("should take an index and return a filename", () => {
       fileNameFormatter({
         index: 0
-      }).should.eql("/path/to/file/thefile.log");
+      }).should.eql(normalize("/path/to/file/thefile.log"));
       fileNameFormatter({ index: 1, date: "" }).should.eql(
-        "/path/to/file/thefile.log.1"
+        normalize("/path/to/file/thefile.log.1")
       );
       fileNameFormatter({ index: 15, date: undefined }).should.eql(
-        "/path/to/file/thefile.log.15"
+        normalize("/path/to/file/thefile.log.15")
       );
       fileNameFormatter({ index: 15 }).should.eql(
-        "/path/to/file/thefile.log.15"
+        normalize("/path/to/file/thefile.log.15")
       );
     });
   });
@@ -37,12 +38,12 @@ describe("fileNameFormatter", () => {
     });
     it("should take an index, date and return a filename", () => {
       fileNameFormatter({ index: 0, date: "2019-07-15" }).should.eql(
-        "/path/to/file/thefile.log"
+        normalize("/path/to/file/thefile.log")
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("/path/to/file/thefile.log.2019-07-16");
+      }).should.eql(normalize("/path/to/file/thefile.log.2019-07-16"));
     });
   });
 
@@ -60,14 +61,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.log.2019-07-15");
+      }).should.eql(normalize("/path/to/file/thefile.log.2019-07-15"));
       fileNameFormatter({ index: 0, date: "2019-07-15" }).should.eql(
-        "/path/to/file/thefile.log.2019-07-15"
+        normalize("/path/to/file/thefile.log.2019-07-15")
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("/path/to/file/thefile.log.2019-07-16");
+      }).should.eql(normalize("/path/to/file/thefile.log.2019-07-16"));
     });
   });
 
@@ -85,11 +86,11 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.log");
-      fileNameFormatter({ index: 1 }).should.eql("/path/to/file/thefile.1.log");
-      fileNameFormatter({ index: 2 }).should.eql("/path/to/file/thefile.2.log");
+      }).should.eql(normalize("/path/to/file/thefile.log"));
+      fileNameFormatter({ index: 1 }).should.eql(normalize("/path/to/file/thefile.1.log"));
+      fileNameFormatter({ index: 2 }).should.eql(normalize("/path/to/file/thefile.2.log"));
       fileNameFormatter({ index: 15 }).should.eql(
-        "/path/to/file/thefile.15.log"
+        normalize("/path/to/file/thefile.15.log")
       );
     });
   });
@@ -108,14 +109,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.log");
+      }).should.eql(normalize("/path/to/file/thefile.log"));
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "/path/to/file/thefile.2019-07-15.log"
+        normalize("/path/to/file/thefile.2019-07-15.log")
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("/path/to/file/thefile.2019-07-16.log");
+      }).should.eql(normalize("/path/to/file/thefile.2019-07-16.log"));
     });
   });
 
@@ -134,14 +135,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.2019-07-15.log");
+      }).should.eql(normalize("/path/to/file/thefile.2019-07-15.log"));
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "/path/to/file/thefile.2019-07-15.log"
+        normalize("/path/to/file/thefile.2019-07-15.log")
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("/path/to/file/thefile.2019-07-16.log");
+      }).should.eql(normalize("/path/to/file/thefile.2019-07-16.log"));
     });
   });
 
@@ -159,13 +160,13 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.log");
+      }).should.eql(normalize("/path/to/file/thefile.log"));
       fileNameFormatter({ index: 1 }).should.eql(
-        "/path/to/file/thefile.log.1.gz"
+        normalize("/path/to/file/thefile.log.1.gz")
       );
       fileNameFormatter({
         index: 2
-      }).should.eql("/path/to/file/thefile.log.2.gz");
+      }).should.eql(normalize("/path/to/file/thefile.log.2.gz"));
     });
   });
 
@@ -183,14 +184,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.log");
+      }).should.eql(normalize("/path/to/file/thefile.log"));
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "/path/to/file/thefile.log.2019-07-15.gz"
+        normalize("/path/to/file/thefile.log.2019-07-15.gz")
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("/path/to/file/thefile.log.2019-07-16.gz");
+      }).should.eql(normalize("/path/to/file/thefile.log.2019-07-16.gz"));
     });
   });
 
@@ -209,14 +210,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.log.2019-07-15");
+      }).should.eql(normalize("/path/to/file/thefile.log.2019-07-15"));
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "/path/to/file/thefile.log.2019-07-15.gz"
+        normalize("/path/to/file/thefile.log.2019-07-15.gz")
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("/path/to/file/thefile.log.2019-07-16.gz");
+      }).should.eql(normalize("/path/to/file/thefile.log.2019-07-16.gz"));
     });
   });
 
@@ -236,14 +237,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.2019-07-15.log");
+      }).should.eql(normalize("/path/to/file/thefile.2019-07-15.log"));
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "/path/to/file/thefile.2019-07-15.log.gz"
+        normalize("/path/to/file/thefile.2019-07-15.log.gz")
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("/path/to/file/thefile.2019-07-16.log.gz");
+      }).should.eql(normalize("/path/to/file/thefile.2019-07-16.log.gz"));
     });
   });
 
@@ -264,14 +265,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.2019-07-15.log");
+      }).should.eql(normalize("/path/to/file/thefile.2019-07-15.log"));
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "/path/to/file/thefile.2019-07-15.1.log.gz"
+        normalize("/path/to/file/thefile.2019-07-15.1.log.gz")
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("/path/to/file/thefile.2019-07-16.2.log.gz");
+      }).should.eql(normalize("/path/to/file/thefile.2019-07-16.2.log.gz"));
     });
   });
 
@@ -287,12 +288,12 @@ describe("fileNameFormatter", () => {
     });
     it("should take an index, date and return a filename", () => {
       fileNameFormatter({ index: 0, date: "2019-07-15" }).should.eql(
-        "/path/to/file/thefile.log"
+        normalize("/path/to/file/thefile.log")
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("/path/to/file/thefile.log.2019-07-16.2");
+      }).should.eql(normalize("/path/to/file/thefile.log.2019-07-16.2"));
     });
   });
 
@@ -311,14 +312,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.log.2019-07-15");
+      }).should.eql(normalize("/path/to/file/thefile.log.2019-07-15"));
       fileNameFormatter({ index: 0, date: "2019-07-15" }).should.eql(
-        "/path/to/file/thefile.log.2019-07-15"
+        normalize("/path/to/file/thefile.log.2019-07-15")
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("/path/to/file/thefile.log.2019-07-16.2");
+      }).should.eql(normalize("/path/to/file/thefile.log.2019-07-16.2"));
     });
   });
 
@@ -337,11 +338,11 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.log");
-      fileNameFormatter({ index: 1 }).should.eql("/path/to/file/thefile.1.log");
-      fileNameFormatter({ index: 2 }).should.eql("/path/to/file/thefile.2.log");
+      }).should.eql(normalize("/path/to/file/thefile.log"));
+      fileNameFormatter({ index: 1 }).should.eql(normalize("/path/to/file/thefile.1.log"));
+      fileNameFormatter({ index: 2 }).should.eql(normalize("/path/to/file/thefile.2.log"));
       fileNameFormatter({ index: 15 }).should.eql(
-        "/path/to/file/thefile.15.log"
+        normalize("/path/to/file/thefile.15.log")
       );
     });
   });
@@ -361,14 +362,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.log");
+      }).should.eql(normalize("/path/to/file/thefile.log"));
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "/path/to/file/thefile.2019-07-15.1.log"
+        normalize("/path/to/file/thefile.2019-07-15.1.log")
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("/path/to/file/thefile.2019-07-16.2.log");
+      }).should.eql(normalize("/path/to/file/thefile.2019-07-16.2.log"));
     });
   });
 
@@ -388,14 +389,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.2019-07-15.log");
+      }).should.eql(normalize("/path/to/file/thefile.2019-07-15.log"));
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "/path/to/file/thefile.2019-07-15.1.log"
+        normalize("/path/to/file/thefile.2019-07-15.1.log")
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("/path/to/file/thefile.2019-07-16.2.log");
+      }).should.eql(normalize("/path/to/file/thefile.2019-07-16.2.log"));
     });
   });
 
@@ -414,13 +415,13 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.log");
+      }).should.eql(normalize("/path/to/file/thefile.log"));
       fileNameFormatter({ index: 1 }).should.eql(
-        "/path/to/file/thefile.log.1.gz"
+        normalize("/path/to/file/thefile.log.1.gz")
       );
       fileNameFormatter({
         index: 2
-      }).should.eql("/path/to/file/thefile.log.2.gz");
+      }).should.eql(normalize("/path/to/file/thefile.log.2.gz"));
     });
   });
 
@@ -439,14 +440,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.log");
+      }).should.eql(normalize("/path/to/file/thefile.log"));
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "/path/to/file/thefile.log.2019-07-15.1.gz"
+        normalize("/path/to/file/thefile.log.2019-07-15.1.gz")
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("/path/to/file/thefile.log.2019-07-16.2.gz");
+      }).should.eql(normalize("/path/to/file/thefile.log.2019-07-16.2.gz"));
     });
   });
 
@@ -466,14 +467,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.log.2019-07-15");
+      }).should.eql(normalize("/path/to/file/thefile.log.2019-07-15"));
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "/path/to/file/thefile.log.2019-07-15.1.gz"
+        normalize("/path/to/file/thefile.log.2019-07-15.1.gz")
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("/path/to/file/thefile.log.2019-07-16.2.gz");
+      }).should.eql(normalize("/path/to/file/thefile.log.2019-07-16.2.gz"));
     });
   });
 
@@ -494,14 +495,14 @@ describe("fileNameFormatter", () => {
       fileNameFormatter({
         index: 0,
         date: "2019-07-15"
-      }).should.eql("/path/to/file/thefile.2019-07-15.log");
+      }).should.eql(normalize("/path/to/file/thefile.2019-07-15.log"));
       fileNameFormatter({ index: 1, date: "2019-07-15" }).should.eql(
-        "/path/to/file/thefile.2019-07-15.1.log.gz"
+        normalize("/path/to/file/thefile.2019-07-15.1.log.gz")
       );
       fileNameFormatter({
         index: 2,
         date: "2019-07-16"
-      }).should.eql("/path/to/file/thefile.2019-07-16.2.log.gz");
+      }).should.eql(normalize("/path/to/file/thefile.2019-07-16.2.log.gz"));
     });
   });
 });


### PR DESCRIPTION
Windows does not like it when you don't close streams properly, resulting in locked files and weird errors. Most of the changes in here fix that, and also the paths expected by the tests.

Also added a `_final` method implementation because we weren't closing the underlying stream sometimes.