### PR TITLE
fix: fallback to copy+truncate on error

### DIFF
--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -1,12 +1,12 @@
 const debug = require("debug")("streamroller:RollingFileWriteStream");
 const fs = require("fs-extra");
-const zlib = require("zlib");
 const path = require("path");
 const newNow = require("./now");
 const format = require("date-format");
 const { Writable } = require("stream");
 const fileNameFormatter = require("./fileNameFormatter");
 const fileNameParser = require("./fileNameParser");
+const moveAndMaybeCompressFile = require("./moveAndMaybeCompressFile");
 
 /**
  * RollingFileWriteStream is mainly used when writing to a file rolling by date or size.
@@ -256,55 +256,6 @@ class RollingFileWriteStream extends Writable {
     return this.options.numToKeep > 0 && numFiles > this.options.numToKeep;
   }
 }
-
-const moveAndMaybeCompressFile = async (
-  sourceFilePath,
-  targetFilePath,
-  needCompress
-) => {
-  if (sourceFilePath === targetFilePath) {
-    debug(
-      `moveAndMaybeCompressFile: source and target are the same, not doing anything`
-    );
-    return;
-  }
-  try {
-    await fs.access(sourceFilePath, fs.constants.W_OK | fs.constants.R_OK);
-
-    debug(
-      `moveAndMaybeCompressFile: moving file from ${sourceFilePath} to ${targetFilePath} ${
-        needCompress ? "with" : "without"
-      } compress`
-    );
-    if (needCompress) {
-      await new Promise((resolve, reject) => {
-        fs.createReadStream(sourceFilePath)
-          .pipe(zlib.createGzip())
-          .pipe(fs.createWriteStream(targetFilePath))
-          .on("finish", () => {
-            debug(
-              `moveAndMaybeCompressFile: finished compressing ${targetFilePath}, deleting ${sourceFilePath}`
-            );
-            fs.unlink(sourceFilePath)
-              .then(resolve)
-              .catch(reject);
-          });
-      });
-    } else {
-      debug(
-        `moveAndMaybeCompressFile: deleting file=${targetFilePath}, renaming ${sourceFilePath} to ${targetFilePath}`
-      );
-      await fs.unlink(targetFilePath).catch(() => {
-        /* doesn't matter */
-      });
-      await fs.rename(sourceFilePath, targetFilePath);
-    }
-  } catch (e) {
-    debug(
-      `moveAndMaybeCompressFile: source file path does not exist. not moving. sourceFilePath=${sourceFilePath}`
-    );
-  }
-};
 
 const deleteFiles = fileNames => {
   debug(`deleteFiles: files to delete: ${fileNames}`);

--- a/lib/moveAndMaybeCompressFile.js
+++ b/lib/moveAndMaybeCompressFile.js
@@ -1,0 +1,58 @@
+const debug = require('debug')('streamroller:moveAndMaybeCompressFile');
+const fs = require('fs-extra');
+const zlib = require('zlib');
+
+const moveAndMaybeCompressFile = async (
+  sourceFilePath,
+  targetFilePath,
+  needCompress
+) => {
+  if (sourceFilePath === targetFilePath) {
+    debug(
+      `moveAndMaybeCompressFile: source and target are the same, not doing anything`
+    );
+    return;
+  }
+    if (await fs.pathExists(sourceFilePath)) {
+
+      debug(
+        `moveAndMaybeCompressFile: moving file from ${sourceFilePath} to ${targetFilePath} ${
+          needCompress ? "with" : "without"
+        } compress`
+      );
+      if (needCompress) {
+        await new Promise((resolve, reject) => {
+          fs.createReadStream(sourceFilePath)
+            .pipe(zlib.createGzip())
+            .pipe(fs.createWriteStream(targetFilePath))
+            .on("finish", () => {
+              debug(
+                `moveAndMaybeCompressFile: finished compressing ${targetFilePath}, deleting ${sourceFilePath}`
+              );
+              fs.unlink(sourceFilePath)
+                .then(resolve)
+                .catch(() => {
+                  debug(`Deleting ${sourceFilePath} failed, truncating instead`);
+                  fs.truncate(sourceFilePath).then(resolve).catch(reject)
+                });
+            });
+        });
+      } else {
+        debug(
+          `moveAndMaybeCompressFile: deleting file=${targetFilePath}, renaming ${sourceFilePath} to ${targetFilePath}`
+        );
+        try {
+          await fs.move(sourceFilePath, targetFilePath, { overwrite: true });
+        } catch (e) {
+          debug(
+            `moveAndMaybeCompressFile: error moving ${sourceFilePath} to ${targetFilePath}`, e
+          );
+          debug(`Trying copy+truncate instead`);
+          await fs.copy(sourceFilePath, targetFilePath, { overwrite: true });
+          await fs.truncate(sourceFilePath);
+        }
+      }
+    }
+};
+
+module.exports = moveAndMaybeCompressFile;

--- a/test/moveAndMaybeCompressFile-test.js
+++ b/test/moveAndMaybeCompressFile-test.js
@@ -1,0 +1,118 @@
+require("should");
+
+const fs = require('fs-extra');
+const path = require('path');
+const zlib = require('zlib');
+const proxyquire = require('proxyquire').noPreserveCache();
+const moveAndMaybeCompressFile = require('../lib/moveAndMaybeCompressFile');
+const TEST_DIR = path.normalize(`/tmp/moveAndMaybeCompressFile_${Math.floor(Math.random()*10000)}`);
+
+describe('moveAndMaybeCompressFile', () => {
+  beforeEach(async () => {
+    await fs.emptyDir(TEST_DIR);
+  });
+
+  after(async () => {
+    await fs.remove(TEST_DIR);
+  });
+
+  it('should move the source file to a new destination', async () => {
+    const source = path.join(TEST_DIR, 'test.log');
+    const destination = path.join(TEST_DIR, 'moved-test.log');
+    await fs.outputFile(source, 'This is the test file.');
+    await moveAndMaybeCompressFile(source, destination);
+
+    const contents = await fs.readFile(destination, 'utf8');
+    contents.should.equal('This is the test file.');
+
+    const exists = await fs.pathExists(source);
+    exists.should.be.false();
+
+  });
+
+  it('should compress the source file at the new destination', async () => {
+    const source = path.join(TEST_DIR, 'test.log');
+    const destination = path.join(TEST_DIR, 'moved-test.log.gz');
+    await fs.outputFile(source, 'This is the test file.');
+    await moveAndMaybeCompressFile(source, destination, true);
+
+    const zippedContents = await fs.readFile(destination);
+    const contents = await new Promise(resolve => {
+      zlib.gunzip(zippedContents, (e, data) => {
+        resolve(data.toString());
+      });
+    });
+    contents.should.equal('This is the test file.');
+
+    const exists = await fs.pathExists(source);
+    exists.should.be.false();
+  });
+
+  it('should do nothing if the source file and destination are the same', async () => {
+    const source = path.join(TEST_DIR, 'pants.log');
+    const destination = path.join(TEST_DIR, 'pants.log');
+    await fs.outputFile(source, 'This is the test file.');
+    await moveAndMaybeCompressFile(source, destination);
+
+    (await fs.readFile(source, 'utf8')).should.equal('This is the test file.');
+  });
+
+  it('should do nothing if the source file does not exist', async () => {
+    const source = path.join(TEST_DIR, 'pants.log');
+    const destination = path.join(TEST_DIR, 'moved-pants.log');
+    await moveAndMaybeCompressFile(source, destination);
+
+    (await fs.pathExists(destination)).should.be.false();
+  });
+
+  it('should use copy+truncate if source file is locked (windows)', async () => {
+    const moveWithMock = proxyquire('../lib/moveAndMaybeCompressFile', {
+      "fs-extra": {
+        exists: () => Promise.resolve(true),
+        move: () => Promise.reject({ code: 'EBUSY', message: 'all gone wrong'}),
+        copy: (fs.copy.bind(fs)),
+        truncate: (fs.truncate.bind(fs))
+      }
+    });
+
+    const source = path.join(TEST_DIR, 'test.log');
+    const destination = path.join(TEST_DIR, 'moved-test.log');
+    await fs.outputFile(source, 'This is the test file.');
+    await moveWithMock(source, destination);
+
+    const contents = await fs.readFile(destination, 'utf8');
+    contents.should.equal('This is the test file.');
+
+    // won't delete the source, but it will be empty
+    (await fs.readFile(source, 'utf8')).should.be.empty()
+
+  });
+
+  it('should truncate file if remove fails when compressed (windows)', async () => {
+    const moveWithMock = proxyquire('../lib/moveAndMaybeCompressFile', {
+      "fs-extra": {
+        exists: () => Promise.resolve(true),
+        unlink: () => Promise.reject({ code: 'EBUSY', message: 'all gone wrong'}),
+        createReadStream: fs.createReadStream.bind(fs),
+        truncate: fs.truncate.bind(fs)
+      }
+    });
+
+    const source = path.join(TEST_DIR, 'test.log');
+    const destination = path.join(TEST_DIR, 'moved-test.log.gz');
+    await fs.outputFile(source, 'This is the test file.');
+    await moveWithMock(source, destination, true);
+
+    const zippedContents = await fs.readFile(destination);
+    const contents = await new Promise(resolve => {
+      zlib.gunzip(zippedContents, (e, data) => {
+        resolve(data.toString());
+      });
+    });
+    contents.should.equal('This is the test file.');
+
+    // won't delete the source, but it will be empty
+    (await fs.readFile(source, 'utf8')).should.be.empty()
+
+  });
+});


### PR DESCRIPTION
This should make things more reliable in Windows, when another process has the source file open. You get an EBUSY error when you try to delete files that something else is reading, so this code falls back to doing a copy and truncate if the move fails.