### PR TITLE
fix: catch unlink errors during cleanup

### DIFF
--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -259,7 +259,9 @@ class RollingFileWriteStream extends Writable {
 
 const deleteFiles = fileNames => {
   debug(`deleteFiles: files to delete: ${fileNames}`);
-  return Promise.all(fileNames.map(f => fs.unlink(f)));
+  return Promise.all(fileNames.map(f => fs.unlink(f).catch((e) => {
+    debug(`deleteFiles: error when unlinking ${f}, ignoring. Error was ${e}`);
+  })));
 };
 
 module.exports = RollingFileWriteStream;

--- a/test/RollingFileWriteStream-test.js
+++ b/test/RollingFileWriteStream-test.js
@@ -1416,4 +1416,26 @@ describe("RollingFileWriteStream", () => {
       s.currentFileStream.emit("error", new Error("oh no"));
     });
   });
+
+  describe("when deleting old files and there is an error", () => {
+    before(done => {
+      fs.ensureDir('/tmp/delete-test/logfile.log.2', done);
+    });
+
+    it("should not let errors bubble up", done => {
+      const s = new RollingFileWriteStream("/tmp/delete-test/logfile.log", {
+        maxSize: 10,
+        numToKeep: 1
+      });
+
+      s.write("length is 10", "utf8", () => {
+        // if there's an error during deletion, then done never gets called
+        s.write("length is 10", "utf8", done);
+      });
+    });
+
+    after(done => {
+      fs.remove('/tmp/delete-test', done);
+    })
+  });
 });


### PR DESCRIPTION
This should fix the problem of unhandled promise rejections during cleanup of old files (mostly a windows problem, I think). See https://github.com/log4js-node/log4js-node/issues/959 for details.