### PR TITLE
add _writev again for batch write logs

### DIFF
--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -115,6 +115,21 @@ class RollingFileWriteStream extends Writable {
     this.currentFileStream.end("", this.options.encoding, callback);
   }
 
+  _writev(chunks, callback) {
+    const buffers = [];
+    const encoding = 'buffer';
+    const len = chunks.length;
+
+    for (let i = 0, chunk = null; i < len; ++i) {
+        chunk = chunks[i];
+        buffers.push(encoding === chunk.encoding ?
+              chunk.chunk :
+              new Buffer(chunk.chunk, chunk.encoding));
+    }
+
+    return this._write(Buffer.concat(buffers), encoding, callback);
+  }
+
   _write(chunk, encoding, callback) {
     this._shouldRoll().then(() => {
       debug(

--- a/test/RollingFileWriteStream-test.js
+++ b/test/RollingFileWriteStream-test.js
@@ -1130,9 +1130,10 @@ describe("RollingFileWriteStream", () => {
       fs.ensureFileSync(fileObj.path);
       fs.writeFileSync(fileObj.path, "This is exactly 30 bytes long\n");
       s = new RollingFileWriteStream(fileObj.path, { maxSize: 35 });
-      s.write("one\n", "utf8"); //34
-      s.write("two\n", "utf8"); //38 - file should be rotated next time
-      s.write("three\n", "utf8", done); // this should be in a new file.
+      s.write("one\n", "utf8", function () { //34
+        s.write("two\n", "utf8"); //38 - file should be rotated next time
+        s.write("three\n", "utf8", done); // this should be in a new file.
+      });
     });
 
     after(done => {
@@ -1169,9 +1170,10 @@ describe("RollingFileWriteStream", () => {
         maxSize: 35,
         flags: "a+"
       });
-      s.write("one\n", "utf8"); //34
-      s.write("two\n", "utf8"); //38 - file should be rotated next time
-      s.write("three\n", "utf8", done); // this should be in a new file.
+      s.write("one\n", "utf8", function () { //34
+        s.write("two\n", "utf8"); //38 - file should be rotated next time
+        s.write("three\n", "utf8", done); // this should be in a new file.
+      });
     });
 
     after(done => {
@@ -1211,9 +1213,10 @@ describe("RollingFileWriteStream", () => {
         maxSize: 30,
         numToKeep: 5
       });
-      s.write("This is exactly 30 bytes long\n", "utf8"); // base.1 -> base.2, base -> base.1
-      s.write("This is exactly 30 bytes long\n", "utf8"); // base.2 -> base.3, base.1 -> base.2, base -> base.1
-      s.write("three\n", "utf8", done); // base.3 -> base.4, base.2 -> base.3, base.1 -> base.2, base -> base.1
+      s.write("This is exactly 30 bytes long\n", "utf8", function () { // base.1 -> base.2, base -> base.1
+        s.write("This is exactly 30 bytes long\n", "utf8"); // base.2 -> base.3, base.1 -> base.2, base -> base.1
+        s.write("three\n", "utf8", done); // base.3 -> base.4, base.2 -> base.3, base.1 -> base.2, base -> base.1
+      });
     });
 
     after(done => {


### PR DESCRIPTION
It is better to add `_writev` function for batch write logs.

The most important point is the performance that improve the speed of log.

but also there will cause some unexpected results, like 
1. the size of log file may bigger that the maxSize when set maxSize config.
2. may cause more memory usage.

Also, I saw the deleted pull request at https://github.com/log4js-node/streamroller/pull/25.
And I fixed the failed test cases.