### PR TITLE
fix: all files ending by a timestamp were validated

### DIFF
--- a/lib/fileNameParser.js
+++ b/lib/fileNameParser.js
@@ -16,12 +16,14 @@ module.exports = ({ file, keepFileExt, pattern }) => {
     return f;
   };
 
+  const __NOT_MATCHING__ = "__NOT_MATCHING__";
+
   const extAtEnd = f => {
     if (f.startsWith(file.name) && f.endsWith(file.ext)) {
       debug("it starts and ends with the right things");
       return f.slice(file.name.length + 1, -1 * file.ext.length);
     }
-    return f;
+    return __NOT_MATCHING__;
   };
 
   const extInMiddle = f => {
@@ -29,7 +31,7 @@ module.exports = ({ file, keepFileExt, pattern }) => {
       debug("it starts with the right things");
       return f.slice(file.base.length + 1);
     }
-    return f;
+    return __NOT_MATCHING__;
   };
 
   const dateAndIndex = (f, p) => {
@@ -53,6 +55,7 @@ module.exports = ({ file, keepFileExt, pattern }) => {
       // components to minimal values in the current timezone instead of UTC,
       // as new Date(0) will do.
       const date = format.parse(pattern, dateStr, new Date(0, 0));
+      if (format.asString(pattern, date) !== dateStr) return f;
       p.index = parseInt(indexStr, 10);
       p.date = dateStr;
       p.timestamp = date.getTime();

--- a/test/fileNameParser-test.js
+++ b/test/fileNameParser-test.js
@@ -42,6 +42,9 @@ describe("fileNameParser", () => {
       should(parser("thefile.log.biscuits")).not.be.ok();
       should(parser("thefile.log.2019")).not.be.ok();
       should(parser("thefile.log.3.2")).not.be.ok();
+      should(parser("thefile.log.04-18")).not.be.ok();
+      should(parser("anotherfile.log.2020-04-18")).not.be.ok();
+      should(parser("2020-05-18")).not.be.ok();
     });
     it("should take a filename and return the date", () => {
       parser("thefile.log.2019-07-17").should.eql({
@@ -112,7 +115,7 @@ describe("fileNameParser", () => {
       pattern: "mm"
     });
     it("should take a filename and return the date", () => {
-      const expectedTimestamp = new Date(0,0);
+      const expectedTimestamp = new Date(0, 0);
       expectedTimestamp.setMinutes(34);
       parser("thing.log.34").should.eql({
         filename: "thing.log.34",
@@ -123,4 +126,55 @@ describe("fileNameParser", () => {
       });
     });
   })
+
+  describe("with a four-digit date pattern", () => {
+    const parser = require("../lib/fileNameParser")({
+      file: {
+        dir: "/path/to/file",
+        base: "stuff.log",
+        ext: ".log",
+        name: "stuff"
+      },
+      pattern: "mm-ss"
+    });
+    it("should return null for files that do not match", () => {
+      should(parser("stuff.log.2020-04-18")).not.be.ok();
+      should(parser("09-18")).not.be.ok();
+    });
+    it("should take a filename and return the date", () => {
+      const expectedTimestamp = new Date(0, 0);
+      expectedTimestamp.setMinutes(34);
+      expectedTimestamp.setSeconds(59);
+      parser("stuff.log.34-59").should.eql({
+        filename: "stuff.log.34-59",
+        date: "34-59",
+        isCompressed: false,
+        index: 0,
+        timestamp: expectedTimestamp.getTime()
+      });
+    });
+    it("should take a filename and return both date and index", () => {
+      const expectedTimestamp_1 = new Date(0, 0);
+      expectedTimestamp_1.setMinutes(7);
+      expectedTimestamp_1.setSeconds(17);
+      parser("stuff.log.07-17.2").should.eql({
+        filename: "stuff.log.07-17.2",
+        index: 2,
+        date: "07-17",
+        timestamp: expectedTimestamp_1.getTime(),
+        isCompressed: false
+      });
+      const expectedTimestamp_2 = new Date(0, 0);
+      expectedTimestamp_2.setMinutes(17);
+      expectedTimestamp_2.setSeconds(30);
+      parser("stuff.log.17-30.3.gz").should.eql({
+        filename: "stuff.log.17-30.3.gz",
+        index: 3,
+        date: "17-30",
+        timestamp: expectedTimestamp_2.getTime(),
+        isCompressed: true
+      });
+    });
+  })
+
 });


### PR DESCRIPTION
Related to issue #60 . Files that :
- have  a "base name" that is not matching the template,
- but were ending by a suitable timestamp
were taken into consideration for the log rolling.