### PR TITLE
Revert "chore(fix): maxSize=0 means no rolling"

### DIFF
--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -27,8 +27,7 @@ class RollingFileWriteStream extends Writable {
    * @param {object} options - The extra options
    * @param {number} options.numToKeep - The max numbers of files to keep.
    * @param {number} options.maxSize - The maxSize one file can reach. Unit is Byte.
-   *                                   This should be more than 1024. If not specified or 0, no rolling will happen.
-   *                                   The default is 0.
+   *                                   This should be more than 1024. The default is Number.MAX_SAFE_INTEGER.
    * @param {string} options.mode - The mode of the files. The default is '0600'. Refer to stream.writable for more.
    * @param {string} options.flags - The default is 'a'. Refer to stream.flags for more.
    * @param {boolean} options.compress - Whether to compress backup files.
@@ -102,7 +101,7 @@ class RollingFileWriteStream extends Writable {
 
   _parseOption(rawOptions) {
     const defaultOptions = {
-      maxSize: 0,
+      maxSize: Number.MAX_SAFE_INTEGER,
       numToKeep: Number.MAX_SAFE_INTEGER,
       encoding: "utf8",
       mode: parseInt("0600", 8),
@@ -112,9 +111,7 @@ class RollingFileWriteStream extends Writable {
       alwaysIncludePattern: false
     };
     const options = Object.assign({}, defaultOptions, rawOptions);
-    if (!options.maxSize) {
-      delete options.maxSize;
-    } else if (options.maxSize <= 0) {
+    if (options.maxSize <= 0) {
       throw new Error(`options.maxSize (${options.maxSize}) should be > 0`);
     }
     // options.numBackups will supercede options.numToKeep

--- a/test/RollingFileStream-test.js
+++ b/test/RollingFileStream-test.js
@@ -1,4 +1,4 @@
-const should = require("should");
+require("should");
 
 const fs = require("fs-extra"),
   path = require("path"),
@@ -90,27 +90,11 @@ describe("RollingFileStream", function() {
 
   describe("without size", function() {
     let stream;
-    it("should default to undefined", function() {
+    it("should default to max int size", function() {
       stream = new RollingFileStream(
         path.join(__dirname, "test-rolling-file-stream")
       );
-      should(stream.size).not.be.ok();
-    });
-
-    after(async function() {
-      await close(stream);
-      await remove("test-rolling-file-stream");
-    });
-  });
-
-  describe("with size 0", function() {
-    let stream;
-    it("should become undefined", function() {
-      stream = new RollingFileStream(
-        path.join(__dirname, "test-rolling-file-stream"),
-        0
-      );
-      should(stream.size).not.be.ok();
+      stream.size.should.eql(Number.MAX_SAFE_INTEGER);
     });
 
     after(async function() {

--- a/test/RollingFileWriteStream-test.js
+++ b/test/RollingFileWriteStream-test.js
@@ -1,4 +1,4 @@
-const should = require("should");
+require("should");
 
 const path = require("path");
 const zlib = require("zlib");
@@ -69,6 +69,9 @@ describe("RollingFileWriteStream", () => {
       (() => {
         new RollingFileWriteStream("filename", { maxSize: -3 });
       }).should.throw("options.maxSize (-3) should be > 0");
+      (() => {
+        new RollingFileWriteStream("filename", { maxSize: 0 });
+      }).should.throw("options.maxSize (0) should be > 0");
     });
 
     it("should complain about a negative numToKeep", () => {
@@ -101,7 +104,7 @@ describe("RollingFileWriteStream", () => {
     });
 
     it("should apply default options", () => {
-      should(s.options.maxSize).not.be.ok();
+      s.options.maxSize.should.eql(Number.MAX_SAFE_INTEGER);
       s.options.encoding.should.eql("utf8");
       s.options.mode.should.eql(0o600);
       s.options.flags.should.eql("a");


### PR DESCRIPTION
Reverts log4js-node/streamroller#129