### PR TITLE
feat: tilde expansion for filename

### DIFF
--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -1,6 +1,7 @@
 const debug = require("debug")("streamroller:RollingFileWriteStream");
 const fs = require("fs-extra");
 const path = require("path");
+const os = require("os");
 const newNow = require("./now");
 const format = require("date-format");
 const { Writable } = require("stream");
@@ -42,6 +43,10 @@ class RollingFileWriteStream extends Writable {
       throw new Error(`Invalid filename: ${filePath}`);
     } else if (filePath.endsWith(path.sep)) {
       throw new Error(`Filename is a directory: ${filePath}`);
+    } else {
+      // handle ~ expansion: https://github.com/nodejs/node/issues/684
+      // exclude ~ and ~filename as these can be valid files
+      filePath = filePath.replace(new RegExp(`^~(?=${path.sep}.+)`), os.homedir());
     }
     super(options);
     this.options = this._parseOption(options);


### PR DESCRIPTION
1. `~` in `~/` or `~\` will be expanded to `os.homedir()`
   (`~` and `~filename` unaffected as these are valid filenames) 