### PR TITLE
fix: fs.appendFileSync should use flag instead of flags

### DIFF
--- a/lib/RollingFileWriteStream.js
+++ b/lib/RollingFileWriteStream.js
@@ -303,8 +303,13 @@ class RollingFileWriteStream extends Writable {
       encoding: this.options.encoding,
       mode: this.options.mode
     };
+    const renameKey = function(obj, oldKey, newKey) {
+      obj[newKey] = obj[oldKey];
+      delete obj[oldKey];
+      return obj;
+    };
     // try to throw EISDIR, EROFS, EACCES
-    fs.appendFileSync(filePath, "", ops);
+    fs.appendFileSync(filePath, "", renameKey({ ...ops }, "flags", "flag"));
     this.currentFileStream = fs.createWriteStream(filePath, ops);
     this.currentFileStream.on("error", e => {
       this.emit("error", e);


### PR DESCRIPTION
Strangely, `fs.appendFileSync` uses `flag` but `fs.createWriteStream` uses `flags`.

It's somewhat inconsistent throughout the Node.js documentation:
https://nodejs.org/api/fs.html