### PR TITLE
ci: replaced deprecated github set-output

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -50,12 +50,7 @@ jobs:
       run: |
         npm -v
         npmMajorVer=$(npm -v | cut -d. -f1)
-        echo "::set-output name=major::$npmMajorVer"
-        if [ $npmMajorVer -le 5 ]; then
-          echo "::set-output name=install::npm install"
-        else 
-          echo "::set-output name=install::npm ci"
-        fi
+        echo "major=$npmMajorVer" >> $GITHUB_OUTPUT
 
     - name: Install downgraded modules ${{ matrix.npm-i }}
       run: |


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/